### PR TITLE
Switched Localstorage cache to use IndexedDB API

### DIFF
--- a/backend/app/now.js
+++ b/backend/app/now.js
@@ -1,0 +1,16 @@
+/*
+* @Author: Milan Donhowe
+* @Date:   Monday September 4th 2021
+* @Last Modified By:  Milan Donhowe
+* @Last Modified Time:  Monday September 4th 2021
+* @Copyright:  Oregon State University 2021
+* @Description: Handler returns current system time in milliseconds
+*               (should be time for AWS services on us-west-2).
+*/
+exports.systemtime = async (event, context) => {
+    return {
+        headers: {},
+        statusCode: 200,
+        body: Date.now().toString()
+    } 
+}

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -42,6 +42,18 @@ Resources:
           Properties:
             Path: /test
             Method: get
+  SystemTime:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 128
+      CodeUri: app/
+      Handler: now.systemtime
+      Events:
+        Building:
+          Type: Api
+          Properties:
+            Path: /systemtime
+            Method: get
   BuildingAll:
     Type: AWS::Serverless::Function
     Properties:

--- a/src/store/api.js
+++ b/src/store/api.js
@@ -86,5 +86,8 @@ export default {
   },
   campaigns: async () => {
     return (await callAPI('campaigns')).data
+  },
+  systemtime: async () => {
+    return (await callAPI('systemtime')).data
   }
 }

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -50,6 +50,7 @@ const actions = {
       this.commit('dataStore/setSystemNow', { now: Number(apiTime) })
     } else {
       // otherwise, fall-back to using locale time
+      console.log('API time route was unavailable, falling back to locale time.')
       this.commit('dataStore/setSystemNow', { now: Date.now() })
     }
   },
@@ -84,7 +85,7 @@ const actions = {
 
       // check if startTime is at least 3 months old
       // then we can be reasonably sure that data for that entry
-      // will not be recovered. (Meters cache data for last 3 months)
+      // will not be recovered. (The AcquiSuites cache data for last 3 months)
       // we calculate 3 months to be about 96 days
       // (this is intended to be an upper-bound to prevent any mislabeling)
       const ThreeMonthsInMilliseconds = 497664000 // = 96 * 24 * 60 * 60 * 60

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -33,7 +33,7 @@ const state = () => {
       //   }
       // }
     },
-    sessionStorageChecked: false
+    localStorageChecked: false
   }
 }
 
@@ -104,8 +104,8 @@ const actions = {
   //  uom: the unit of measure/metering point to request data for
   //  classInt: An integer that corresponds to the type of meter we are reading from
   async getData (store, payload) {
-    // First, attempt to load a cache from sessionStorage (if the cache is empty)
-    this.commit('dataStore/loadSessionStorage')
+    // First, attempt to load a cache from localstorage (if the cache is empty)
+    this.commit('dataStore/loadLocalStorage')
 
     // Does the cache contain the data?
     const missingIntervals = await this.dispatch('dataStore/findMissingIntervals', {
@@ -142,7 +142,7 @@ const actions = {
         })
       })
       try {
-        window.sessionStorage.setItem('OSU Sustainability Office Energy Dashboard Data Cache', JSON.stringify(this.getters['dataStore/cache']))
+        window.localStorage.setItem('OSU Sustainability Office Energy Dashboard Data Cache', JSON.stringify(this.getters['dataStore/cache']))
       } catch (e) {
         console.log(e)
         console.log('Failed to write new datums to the persistent cache.')
@@ -193,11 +193,11 @@ const mutations = {
     state.cache[cacheEntry.meterId][cacheEntry.uom][cacheEntry.datetime] = cacheEntry.value
   },
 
-  loadSessionStorage: (state) => {
+  loadLocalStorage: (state) => {
     try {
-      if (!state.sessionStorageChecked) {
-        state.sessionStorageChecked = true
-        const temp = JSON.parse(window.sessionStorage.getItem('OSU Sustainability Office Energy Dashboard Data Cache'))
+      if (!state.localStorageChecked) {
+        state.localStorageChecked = true
+        const temp = JSON.parse(window.localStorage.getItem('OSU Sustainability Office Energy Dashboard Data Cache'))
         if (temp) {
           state.cache = temp
           console.log('Data loaded from persistent cache.')

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -33,11 +33,20 @@ const state = () => {
       //   }
       // }
     },
-    indexedDBInstance: undefined
+    indexedDBInstance: undefined,
+    remoteSystemNow: undefined
   }
 }
 
 const actions = {
+
+  // Queries backend-api to get "system.now()" timestamp
+  // this is to ensure DeadRequests doesn't improperly
+  // mark intervals as "unavailable."
+  async getSystemNow(store){
+    // TODO: add API request to <apiurl>/now/ or something
+    thisDate.now()
+  },
 
   // Copies "cache" object to indexedDB for persistent storage
   async addCacheToIndexedDB (store) {
@@ -364,7 +373,11 @@ const mutations = {
   // Needed for indexedDB load action to change cache state.
   overwriteCache: (state, { newCache }) => {
     state.cache = newCache
-  }
+  },
+
+  setSystemNow: (state, { now }) => {
+    state.remoteSystemNow = now
+  },
 }
 
 const getters = {
@@ -373,6 +386,9 @@ const getters = {
   },
   DB (state) {
     return state.indexedDBInstance
+  },
+  SystemNow (state){
+    return state.remoteSystemNow
   }
 }
 

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -33,7 +33,7 @@ const state = () => {
       //   }
       // }
     },
-    localStorageChecked: false
+    sessionStorageChecked: false
   }
 }
 
@@ -104,8 +104,8 @@ const actions = {
   //  uom: the unit of measure/metering point to request data for
   //  classInt: An integer that corresponds to the type of meter we are reading from
   async getData (store, payload) {
-    // First, attempt to load a cache from localstorage (if the cache is empty)
-    this.commit('dataStore/loadLocalStorage')
+    // First, attempt to load a cache from sessionStorage (if the cache is empty)
+    this.commit('dataStore/loadSessionStorage')
 
     // Does the cache contain the data?
     const missingIntervals = await this.dispatch('dataStore/findMissingIntervals', {
@@ -142,7 +142,7 @@ const actions = {
         })
       })
       try {
-        window.localStorage.setItem('OSU Sustainability Office Energy Dashboard Data Cache', JSON.stringify(this.getters['dataStore/cache']))
+        window.sessionStorage.setItem('OSU Sustainability Office Energy Dashboard Data Cache', JSON.stringify(this.getters['dataStore/cache']))
       } catch (e) {
         console.log(e)
         console.log('Failed to write new datums to the persistent cache.')
@@ -193,11 +193,11 @@ const mutations = {
     state.cache[cacheEntry.meterId][cacheEntry.uom][cacheEntry.datetime] = cacheEntry.value
   },
 
-  loadLocalStorage: (state) => {
+  loadSessionStorage: (state) => {
     try {
-      if (!state.localStorageChecked) {
-        state.localStorageChecked = true
-        const temp = JSON.parse(window.localStorage.getItem('OSU Sustainability Office Energy Dashboard Data Cache'))
+      if (!state.sessionStorageChecked) {
+        state.sessionStorageChecked = true
+        const temp = JSON.parse(window.sessionStorage.getItem('OSU Sustainability Office Energy Dashboard Data Cache'))
         if (temp) {
           state.cache = temp
           console.log('Data loaded from persistent cache.')

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -243,11 +243,13 @@ const actions = {
 
     // remove already checked intervals (intervals where data presumably doesn't exist on server)
     // this should prevent extraneous GET requests from occuring on the front-end
-    missingIntervals = missingIntervals.filter(async (interval) => {
+    let newMissingIntervals = []
+    for (let interval of missingIntervals) {
       let [startTime, end] = interval
       let endPoints = await this.dispatch('dataStore/getDeadQueries', { startTime })
-      return !endPoints.includes(end)
-    })
+      if (!endPoints.includes(end)) newMissingIntervals.push(interval)
+    }
+    missingIntervals = newMissingIntervals
 
     if (missingIntervals.length > 0) {
       // The cache does not contain all of the data

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -43,9 +43,17 @@ const actions = {
   // Queries backend-api to get "system.now()" timestamp
   // this is to ensure DeadRequests doesn't improperly
   // mark intervals as "unavailable."
-  async getSystemNow(store){
-    // TODO: add API request to <apiurl>/now/ or something
-    thisDate.now()
+  async loadSystemNow(store){
+    
+    let apiTime = await API.systemtime()
+    if (apiTime){
+      console.log(`== the api time is ${apiTime}`)
+      this.commit('dataStore/setSystemNow', { now: Number(apiTime) })
+    } else {
+      // fall-back to local time
+      console.log('could not query api, falling back to locale time...')
+      this.commit('dataStore/setSystemNow', { now: thisDate.now() })
+    }
   },
 
   // Copies "cache" object to indexedDB for persistent storage
@@ -75,6 +83,15 @@ const actions = {
     MissingPairs.forEach(async pair => {
       // updates stored dead intervals
       let [startTime, endTime] = pair
+      
+      // check if startTime is at least 3 months old
+      // then we can be reasonably sure that data for that entry
+      // will not be recovered. (Meters cache data for last 3 months)
+      // we calculate 3 months to be about 96 days 
+      // (this is intended to be an upper-bound to prevent any mislabeling)
+      const ThreeMonthsInMilliseconds = 497664000 // = 96 * 24 * 60 * 60 * 60
+      if (startTime < (this.getters['dataStore/remoteSystemNow'] - ThreeMonthsInMilliseconds)) return
+
       let currentEndTimes = await this.dispatch('dataStore/getDeadQueries', { startTime })
       await new Promise((resolve, reject) => {
         let request = db.transaction('DeadRequests', 'readwrite').objectStore('DeadRequests').put({ startTime, endingTimes: [...currentEndTimes, endTime] })
@@ -126,6 +143,12 @@ const actions = {
   //  }
   async loadIndexedDB (store) {
     if (this.getters['dataStore/DB'] !== undefined) return
+
+    // Alright, since we need to setup our database 
+    // let's first set the current time for the Dead Requests Store
+    // (this is used later for checking if data is sufficiently old enough
+    // to be declared "dead").
+    await this.dispatch('dataStore/loadSystemNow')
 
     // connect to indexedDB instance
     await new Promise((resolve, reject) => {

--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -43,16 +43,14 @@ const actions = {
   // Queries backend-api to get "system.now()" timestamp
   // this is to ensure DeadRequests doesn't improperly
   // mark intervals as "unavailable."
-  async loadSystemNow(store){
-    
+  async loadSystemNow (store) {
     let apiTime = await API.systemtime()
-    if (apiTime){
-      console.log(`== the api time is ${apiTime}`)
+    // see if we can set the apiTime from querying AWS
+    if (apiTime) {
       this.commit('dataStore/setSystemNow', { now: Number(apiTime) })
     } else {
-      // fall-back to local time
-      console.log('could not query api, falling back to locale time...')
-      this.commit('dataStore/setSystemNow', { now: thisDate.now() })
+      // otherwise, fall-back to using locale time
+      this.commit('dataStore/setSystemNow', { now: Date.now() })
     }
   },
 
@@ -83,11 +81,11 @@ const actions = {
     MissingPairs.forEach(async pair => {
       // updates stored dead intervals
       let [startTime, endTime] = pair
-      
+
       // check if startTime is at least 3 months old
       // then we can be reasonably sure that data for that entry
       // will not be recovered. (Meters cache data for last 3 months)
-      // we calculate 3 months to be about 96 days 
+      // we calculate 3 months to be about 96 days
       // (this is intended to be an upper-bound to prevent any mislabeling)
       const ThreeMonthsInMilliseconds = 497664000 // = 96 * 24 * 60 * 60 * 60
       if (startTime < (this.getters['dataStore/remoteSystemNow'] - ThreeMonthsInMilliseconds)) return
@@ -144,10 +142,10 @@ const actions = {
   async loadIndexedDB (store) {
     if (this.getters['dataStore/DB'] !== undefined) return
 
-    // Alright, since we need to setup our database 
+    // Alright, since we need to setup our database
     // let's first set the current time for the Dead Requests Store
     // (this is used later for checking if data is sufficiently old enough
-    // to be declared "dead").
+    // to be declared as "dead").
     await this.dispatch('dataStore/loadSystemNow')
 
     // connect to indexedDB instance
@@ -400,7 +398,7 @@ const mutations = {
 
   setSystemNow: (state, { now }) => {
     state.remoteSystemNow = now
-  },
+  }
 }
 
 const getters = {
@@ -410,7 +408,7 @@ const getters = {
   DB (state) {
     return state.indexedDBInstance
   },
-  SystemNow (state){
+  SystemNow (state) {
     return state.remoteSystemNow
   }
 }


### PR DESCRIPTION
Alright, I'm opening this pull-request because _I think_ this should fix issue #119.  I've organized this PR into three parts so hopefully that will make it easier to review my code.

### 1. Problems in current setup
Foremost, this pull requests seeks to fix two issues raised by #119:

1. The cache size was exceeding localStorage's capacity
2. The dashboard was making extraneous requests for data that did not exist:

For instance, if you load up [Arnold Hall](https://dashboard.sustainability.oregonstate.edu/#/building/14/2) in the console you'll notice it is always `GET` requesting the interval between `1613213100` & `1613222100` (time between 2:45 AM & 5:15 AM on February 13th).  From what I can tell by directly querying for this interval on SQL-workbench, it seems this data just does not exist, I just get a bunch of `null` values.  Since there's no current mechanism for the dashboard to tell if data does not exist for an interval, it will always re-query for this interval upon reloading a page.

### 2. Quick Summary of Changes
Basically all I did was switch the cache system in `data_store.js` from using [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) (whose capacity we were frequently exceeding) to [indexedDB](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API) which should allow us to store a lot more data in an ideally more convenient fashion.

Previously, data_store.js was caching data through a java-script object called `cache` which would then get stringified by JSON.stringify and stored as-is in localStorage. 

PR provides two indexedDB object stores which supplant localStorage:
- `MeterReadings`: used to store & retrieve `cache` object (indexed by `meterId`)
- `DeadRequests`:  used to track `missingIntervals` for which data cannot be retrieved (indexed by `startTime`)
Note: DeadRequests shouldn't track missingIntervals if the API request failed (e.g. API is down for some reason).
### 3. Itemized List of Changes

Here is a description of each added function & each modification made to previously existing functions in `data_store.js`

**Added Actions:**
- `loadIndexedDB`: Loads the indexedDB instance into the Vuex store. 
- `addCacheToIndexedDB`: Stores `cache` object into the `MeterReadings` object store in IndexedDB.
- `addDeadQueries`: Adds new interval pairs to the `DeadRequest` store.
- `getDeadQueries`: Returns ending timestamps corresponding to a given start timestamp.

**Modified Actions:**
- `getData`: I added calls to all the above actions and implemented some logic to remove already checked missing intervals from being requested again.

**Added Mutators:**
- `setDBInstance`: Sets the `indexedDBInstance` variable in the store to a given db instance (used by `loadIndexedDB`).
- `overwriteCache`: Replaces the entire `cache` object with supplied object (used by `loadIndexedDB`).

**Added Getter:**
- `DB`: returns variable holding an initialized indexedDB instance
