### PR TITLE
bugfix for remote systemtime fail

### DIFF
--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -45,6 +45,7 @@ const actions = {
   // mark intervals as "unavailable."
   async loadSystemNow (store) {
     let apiTime = await API.systemtime()
+      .catch(fail => {}) // empty catch prevents front-end from halting on error
     // see if we can set the apiTime from querying AWS
     if (apiTime) {
       this.commit('dataStore/setSystemNow', { now: Number(apiTime) })


### PR DESCRIPTION
This is a really short one-line fix to one of the errors which occurred yesterday when the system didn't fall back to the locale `Date.now()` timestamp.  It looks kinda useless but without the empty catch statement the API request will throw an error out and therefore halt the rest of the cache queries (as we saw yesterday).