### PR TITLE
Add chart arrows#132

### DIFF
--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -1,25 +1,34 @@
 <template>
-  <el-row class="card" ref='card'>
-    <el-col :span='24'>
-      <el-row class='title' ref='title'>
+  <div class="card" ref='card'>
+      <el-row :span='24' class='title' ref='title'>
         <el-col :span='20'>{{ name }}</el-col>
         <el-col :span='4' v-if='personalView || publicView' class='right'>&nbsp;<i class="fas fa-sliders-h" @click='openModal()'></i></el-col>
       </el-row>
+
+      <!--Next/Previous Buttons-->
+      <el-row :span='24'>
+        <el-col :span='12' class='buttonDisplay'>
+            <el-button size='small' type='primary' class='moveButtons' @click='previousInterval' icon='el-icon-d-arrow-left'>
+              Previous
+            </el-button>
+        </el-col>
+        <el-col :span='12'>
+          <el-row type='flex' justify='end'>
+            <el-button size='small' type='primary' class='moveButtons' @click='nextInterval' :disabled='!nextExists'>
+              Next <i class='el-icon-d-arrow-right'></i>
+            </el-button>
+          </el-row>
+        </el-col>
+      </el-row>
+
       <!--Chart Below-->
       <el-row style='overflow: hidden;' :span='24'>
-        <el-col :span='1'>
-          <el-button class='moveButtons' size="small" type='primary' icon='el-icon-d-arrow-left' @click='previousInterval' :disabled='!prevExists'></el-button>
-        </el-col>
-        <el-col :span='22'>
+        <el-col :span='24'>
           <!--If you change the "height" attribute here, remember to also change the chart-height variable in the scss-->
           <chartController :randomColors='1' :path='path' ref="chartController"  class="chart" :styleC='style' :height='430'/>
         </el-col>
-        <el-col :span='1'>
-          <el-button class='moveButtons' size="small" type='primary' icon='el-icon-d-arrow-right' @click='nextInterval' :disabled='!nextExists'></el-button>
-        </el-col>
       </el-row>
-  </el-col>
-  </el-row>
+  </div>
 </template>
 
 <script>
@@ -215,7 +224,9 @@ $chart-height: 430px;
   text-align: right;
 }
 .moveButtons {
-  height: $chart-height;
+  //height: $chart-height;
+  height: 3em;
+  width: 10em;
 }
 
 </style>

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -11,10 +11,7 @@
           <el-button class='moveButtons' size="small" type='primary' icon='el-icon-d-arrow-left' @click='previousInterval' :disabled='!prevExists'></el-button>
         </el-col>
         <el-col :span='22'>
-<<<<<<< HEAD
           <!--If you change the "height" attribute here, remember to also change the chart-height variable in the scss-->
-=======
->>>>>>> 7ffbcb9f9f365d72910f179442301042d9582f6c
           <chartController :randomColors='1' :path='path' ref="chartController"  class="chart" :styleC='style' :height='430'/>
         </el-col>
         <el-col :span='1'>

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -213,7 +213,6 @@ $chart-height: 430px;
 }
 .right {
   text-align: right;
-  padding-right: 10px;
 }
 .moveButtons {
   height: $chart-height;

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -11,6 +11,7 @@
           <el-button class='moveButtons' size="small" type='primary' icon='el-icon-d-arrow-left' @click='previousInterval' :disabled='!prevExists'></el-button>
         </el-col>
         <el-col :span='22'>
+          <!--If you change the "height" attribute here, remember to also change the chart-height variable in the scss-->
           <chartController :randomColors='1' :path='path' ref="chartController"  class="chart" :styleC='style' :height='430'/>
         </el-col>
         <el-col :span='1'>
@@ -124,16 +125,14 @@ export default {
     },
     // returns boolean for if next interval exists in program.
     nextExists: function () {
-      return this.nextEndpoint < Date.now()
+      return this.nextEndpoint < this.$store.getters['dataStore/SystemNow']
     },
     // returns boolean for if prev interval exists in program
     prevExists: function () {
-      // !! WARNING: THIS IS HARDCODED, WE SHOULD HAVE ANOTHER
-      // !! (server-side) MECHANISM TO CHECK THE OLDEST DATA DATE
-      // !! DO NOT MERGE THIS: WILL CREATE PROBLEMS LATER ON
-      // !! IT DOESN'T TAKE INTO ACCOUNT DIFFERENT METERS
-      // check if user is asking for data in the past
-      // earliest record in energy_data right now is from 2018--this is its timestamp.
+      // Check if user is asking for data in the past,
+      // since the earliest record in energy_data right now is from 2018
+      // this is the hard-coded in time-stamp and may be subject to change
+      // depending on how far back our records go.
       return this.nextStartpoint > 1527836400000
     },
     // holds next possible interval start
@@ -187,6 +186,9 @@ export default {
 
 <!-- Add "scoped" attribute to limit CSS to this component only -->
 <style scoped lang='scss'>
+
+$chart-height: 430px;
+
 .card {
   background-color: $--color-white;
   padding: 2em;
@@ -213,8 +215,7 @@ export default {
   text-align: right;
 }
 .moveButtons {
-  margin-top: 0 auto;
-  height: calc( (400px + 8em) * 0.8)
+  height: $chart-height;
 }
 
 </style>

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -5,6 +5,20 @@
         <el-col :span='20'>{{ name }}</el-col>
         <el-col :span='4' v-if='personalView || publicView' class='right'>&nbsp;<i class="fas fa-sliders-h" @click='openModal()'></i></el-col>
       </el-row>
+      <!--Next/Previous arrows on graph-->
+      <el-row class='GraphChangeButtons' ref='GraphChangeButtons'>
+        <el-col :span='20'>
+          <el-button-group>
+            <el-button size="small" type='primary' icon='el-icon-d-arrow-left' @click='previousInterval'>
+              Previous {{ currentTimeInterval() }}
+            </el-button>
+            <el-button size="small" type='primary' disabled>
+              Next {{ currentTimeInterval() }} <i class="el-icon-d-arrow-right" @click='nextInterval'></i>
+            </el-button>
+          </el-button-group>
+        </el-col>
+      </el-row>
+      <!--Chart Below-->
       <el-row style='overflow: hidden;'>
         <chartController :randomColors='1' :path='path' ref="chartController"  class="chart" :styleC='style' :height='430'/>
       </el-row>
@@ -133,6 +147,26 @@ export default {
       // this.$store.dispatch('block', block).then(() => {
       //   this.$refs.chartController.parse()
       // })
+    },
+    // returns current interval of chart data: [start, end]
+    currentTimeInterval: function () {
+          // get date start & end
+          const blockPath = this.$store.getters['modalController/data'].path
+          console.log(blockPath)
+          if (blockPath) {
+            let startDate = this.$store.getters[blockPath + '/dateStart']
+            let endDate = this.$store.getters[blockPath + '/dateEnd']
+            console.log(`== ${startDate}, ${endDate}`)
+          }
+          return 'TODO' 
+    },
+    // Moves the chart data to its previous occuring interval
+    previousInterval: function () {
+      // TODO 
+    },
+    // Moves chart data to its next occuring interval
+    nextInterval: function () {
+      // TODO 
     }
   }
 }

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -125,7 +125,7 @@ export default {
     },
     // returns boolean for if next interval exists in program.
     nextExists: function () {
-      return this.nextEndpoint < this.$store.getters['dataStore/SystemNow']
+      return this.nextEndpoint < Date.now()
     },
     // returns boolean for if prev interval exists in program
     prevExists: function () {
@@ -213,6 +213,7 @@ $chart-height: 430px;
 }
 .right {
   text-align: right;
+  padding-right: 10px;
 }
 .moveButtons {
   height: $chart-height;


### PR DESCRIPTION
This is a PR to resolve issue #132. This PR provides next/previous arrows to the charts in order to scroll through them easily.  The only modified file is `card.vue`. 

Here's a gif of the current arrows functioning: ![animated image of arrow buttons](https://raw.githubusercontent.com/MilanDonhowe/ReadmeImages/master/ArrowButtonsDashboard.gif)

Since this is a UI change I'll likely need feedback and approval from Brandon & Lety for the change but I wanted to have this PR up in order for code review / documentation purposes.