### PR TITLE
Fix card graph padding

### DIFF
--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -200,7 +200,7 @@ $chart-height: 430px;
 .card {
   background-color: $--color-white;
   padding: 2em;
-  padding-bottom: 4em;
+  padding-bottom: 5em;
   height: calc(400px + 8em);
   color: $--color-primary;
   margin-top: 1em;

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -20,7 +20,6 @@
           </el-row>
         </el-col>
       </el-row>
-
       <!--Chart Below-->
       <el-row style='overflow: hidden;' :span='24'>
         <el-col :span='24'>
@@ -201,6 +200,7 @@ $chart-height: 430px;
 .card {
   background-color: $--color-white;
   padding: 2em;
+  padding-bottom: 4em;
   height: calc(400px + 8em);
   color: $--color-primary;
   margin-top: 1em;


### PR DESCRIPTION
Right now the axis of the graphs from the buildings tab dip [below the lower card border ](https://dashboard.sustainability.oregonstate.edu/#/building/16/2)and this fixes that issue by adding additional padding to the bottom of the card div container.
