### PR TITLE
Refactored range difference check for solar panels

### DIFF
--- a/src/components/building_list/building_list.vue
+++ b/src/components/building_list/building_list.vue
@@ -15,8 +15,7 @@
               <span slot='label' class='tab_label'>{{ key }}</span>
               <el-row type='flex' justify='left' class='card_flex'>
                 <el-col v-for='building in item' :key='building.name' :span='4' class='card_container'>
-                  <viewCard v-if="building.group === 'Solar'" :plus='false' :building='buildingList' :id='building.id' class='card' @click='$router.push({ path: `/building/${building.id}/4` })' ref='card' />
-                  <viewCard v-else :plus='false' :building='buildingList' :id='building.id' class='card' @click='$router.push({ path: `/building/${building.id}/2` })' ref='card' />
+                  <viewCard :plus='false' :building='buildingList' :id='building.id' class='card' @click='$router.push({ path: `/building/${building.id}/2` })' ref='card' />
                 </el-col>
                 <!-- Add some extra padding for proper alignment, this kind of an estimated number. -->
                 <el-col v-for='n in 10' :key='key + n' :span='4' class='blankSlate'>

--- a/src/components/view/view.vue
+++ b/src/components/view/view.vue
@@ -215,13 +215,22 @@ export default {
     },
     intervalUnit: {
       get () {
+        /*
+         If we're dealing with solar panels just show the interval in hours or minutes since the
+         default unit for solar panels is Energy in Interval--basically the change in
+         energy absorbed over a time frame, so any range greater than an hour will make ChartJS
+         produce a trendline of zero (horizontal line) which isn't particularly useful for anyone.
+        */
+        const isSolar = this.$store.getters[`map/building_${this.$route.params.id}/meterGroups`][0].type === 'Solar Panel'
+
         switch (parseInt(this.$route.params.range)) {
-          case 4:
           case 1:
             return 'hour'
           case 2:
+            if (isSolar) return 'hour'
             return 'day'
           case 3:
+            if (isSolar) return 'hour'
             return 'day'
           default:
             return 'minute'


### PR DESCRIPTION
Now the linked full-view graphs of Solar panels will only show interval ticks of hours or minutes (otherwise chartJS will produce a constant horizontal trend-line since our default unit is Energy in Interval which will always average to zero).