### PR TITLE
attempting to add gzip compression to API responses.

### DIFF
--- a/backend/app/building.js
+++ b/backend/app/building.js
@@ -13,6 +13,7 @@ const User = require('/opt/nodejs/user.js')
 exports.all = async (event, context) => {
   let response = new Response(event)
   response.body = JSON.stringify((await Building.all()).map(o => o.data))
+  response.headers['Content-Type'] = 'application/json'
   return response
 }
 

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -24,6 +24,7 @@ Globals:
       - image~1jpeg
       - application/octet-stream
       - multipart/form-data
+    MinimumCompressionSize: 80000
 Parameters:
   LambdaCommonLayer:
     Type: String


### PR DESCRIPTION
Referencing: [this post on the AWS Docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gzip-compression-decompression.html).

This doesn't seem to work locally when doing `sam local start-api` but I'm going to see if that's just a limitation of the local sam cli testing by deploying the new template.