### PR TITLE
Added response compression to data routes

### DIFF
--- a/backend/app/building.js
+++ b/backend/app/building.js
@@ -9,12 +9,13 @@
 const Building = require('/opt/nodejs/models/building.js')
 const Response = require('/opt/nodejs/response.js')
 const User = require('/opt/nodejs/user.js')
+const Compress = require('/opt/nodejs/models/compress.js')
 
 exports.all = async (event, context) => {
   let response = new Response(event)
   response.body = JSON.stringify((await Building.all()).map(o => o.data))
   response.headers['Content-Type'] = 'application/json'
-  return response
+  return Compress(event, response)
 }
 
 exports.get = async (event, context) => {

--- a/backend/app/meter.js
+++ b/backend/app/meter.js
@@ -9,6 +9,8 @@ const Response = require('/opt/nodejs/response.js')
 const User = require('/opt/nodejs/user.js')
 const MultipartParse = require('/opt/nodejs/node_modules/aws-lambda-multipart-parser')
 const ZLib = require('zlib')
+const Compress = require('/opt/nodejs/models/compress.js')
+
 
 exports.get = async (event, context) => {
   let response = new Response(event)
@@ -68,7 +70,7 @@ exports.batchData = async (event, context) => {
     })
   }
   response.body = JSON.stringify(response.body)
-  return response
+  return Compress(event, response)
 }
 
 // GET data for single meter
@@ -80,7 +82,7 @@ exports.data = async (event, context) => {
     event.queryStringParameters['endDate'],
     event.queryStringParameters['meterClass']
   )))
-  return response
+  return Compress(event, response)
 }
 
 // Meter Data Upload Route (currently only for solar panels)

--- a/backend/dependencies/nodejs/models/compress.js
+++ b/backend/dependencies/nodejs/models/compress.js
@@ -8,7 +8,6 @@ function compress(event, response) {
   }
 
   const encodingHeader = event.headers['Accept-Encoding']
-  console.log(encodingHeader)
   const encodings = new Set()
   if (encodingHeader) {
     encodingHeader.split(',').forEach((encoding) => {
@@ -19,7 +18,6 @@ function compress(event, response) {
   if (!response.headers) {
     response.headers = {}
   }
-  console.log(encodings)
   if (encodings.has('br')) {
     response.headers['Content-Encoding'] = 'br'
     response.isBase64Encoded = true

--- a/backend/dependencies/nodejs/models/compress.js
+++ b/backend/dependencies/nodejs/models/compress.js
@@ -1,0 +1,47 @@
+// Lambda Compression for API Responses from https://www.npmjs.com/package/lambda-compression
+
+const zlib = require('zlib')
+
+function compress(event, response) {
+  if (!response.body) {
+    return result
+  }
+
+  const encodingHeader = event.headers['Accept-Encoding']
+  console.log(encodingHeader)
+  const encodings = new Set()
+  if (encodingHeader) {
+    encodingHeader.split(',').forEach((encoding) => {
+      encodings.add(encoding.toLowerCase().trim())
+    })
+  }
+
+  if (!response.headers) {
+    response.headers = {}
+  }
+  console.log(encodings)
+  if (encodings.has('br')) {
+    response.headers['Content-Encoding'] = 'br'
+    response.isBase64Encoded = true
+    response.body = zlib.brotliCompressSync(response.body).toString('base64')
+    return response
+  }
+
+  if (encodings.has('gzip')) {
+    response.headers['Content-Encoding'] = 'gzip'
+    response.isBase64Encoded = true
+    response.body = zlib.gzipSync(response.body).toString('base64')
+    return response
+  }
+
+  if (encodings.has('deflate')) {
+    response.headers['Content-Encoding'] = 'deflate'
+    response.isBase64Encoded = true
+    response.body = zlib.deflateSync(response.body).toString('base64')
+    return response
+  }
+
+  return response
+}
+
+module.exports = compress

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -24,7 +24,6 @@ Globals:
       - image~1jpeg
       - application/octet-stream
       - multipart/form-data
-    MinimumCompressionSize: 80000
 Parameters:
   LambdaCommonLayer:
     Type: String
@@ -69,7 +68,7 @@ Resources:
         - !Ref EnergyModelLayer
       Events:
         Building:
-          Type: Api
+          Type: HttpApi
           Properties:
             Path: /allbuildings
             Method: get
@@ -219,7 +218,7 @@ Resources:
         - !Ref EnergyModelLayer
       Events:
         Building:
-          Type: Api
+          Type: HttpApi
           Properties:
             Path: /data
             Method: get
@@ -235,7 +234,7 @@ Resources:
         - !Ref EnergyModelLayer
       Events:
         Building:
-          Type: Api
+          Type: HttpApi
           Properties:
             Path: /batchData
             Method: post

--- a/backend/tests/setupBackendTests.js
+++ b/backend/tests/setupBackendTests.js
@@ -60,7 +60,8 @@ const modelMocks = [
   'models/meter.js',
   'models/meter_group.js',
   'models/building.js',
-  'models/campaign.js'
+  'models/campaign.js',
+  'models/compress.js'
 ]
 for (modelMock of modelMocks) {
   const mock = require(`../dependencies/nodejs/${modelMock}`)


### PR DESCRIPTION
This PR also helps to address #123 by reducing the response size returned by the Lambda API for the `/allbuildings` `/data` and `/batchData` routes.

Previous to this PR, allbuildings had a response size of 167kb (167,451 bytes).  With Brotli compression it's 3kb (3341 bytes).

This PR does require shifting these routes from using AWS's REST API calls to using AWS's HTTP API calls (both of them use http, the name difference is just how amazon distinguishes the services) which means we won't have any fancy AWS caching out-of-the-box, but I expect the speed-up from compression will overcome that particular deficiency. 
