### PR TITLE
Create API-deploy.yml

### DIFF
--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
-        sam deploy --template-file /home/runner/work/energy-dashboard/energy-dashboard/backend/packaged.yaml --stack-name energy
+        sam deploy --template-file /home/runner/work/energy-dashboard/energy-dashboard/backend/packaged.yaml --stack-name energy --no-confirm-changeset --no-fail-on-empty-changeset
     - name: deploy frontend
       run: |
         aws s3 sync ./dist s3://energy-dashboard

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -4,18 +4,6 @@ on:
     branches:
       - ci-github-actions
 jobs:
-  run-npm-build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-           node-version: 16
-      - name: npm install and build
-        run: |
-          npm install
-          npm run build-stage
-
   deploy-sam:
     name: Deploy Serveless API
     runs-on: ubuntu-latest
@@ -23,11 +11,16 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
     - uses: aws-actions/setup-sam@v1
+    - uses: actions/setup-node@v3
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
+    - name: npm install and build
+      run: |
+          npm install
+          npm run build-stage
     - name: Deploy
       working-directory: backend
       run: |

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with: 
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-python@v2
     - uses: aws-actions/setup-sam@v1
     - uses: actions/setup-node@v3

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -25,16 +25,16 @@ jobs:
       run: |
           npm install
           npm run build-stage
-    - name: Build Backend
-      working-directory: backend
-      run: |
-        sam build --use-container
     - name: Deploy
       working-directory: backend
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --capabilities CAPABILITY_IAM --region us-west-2
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
     - name: deploy frontend
       run: |
         aws s3 sync ./dist s3://energy-dashboard

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
+        sam deploy --template-file /home/runner/work/energy-dashboard/energy-dashboard/backend/packaged.yaml --stack-name energy
     - name: deploy frontend
       run: |
         aws s3 sync ./dist s3://energy-dashboard

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -34,4 +34,7 @@ jobs:
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
-        sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2
+        sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --capabilities CAPABILITY_IAM --region us-west-2
+    - name: deploy frontend
+      run: |
+        aws s3 sync ./dist s3://energy-dashboard

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -7,14 +7,14 @@ jobs:
   run-npm-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+           node-version: 16
       - name: npm install and build
         run: |
           npm install
           npm run build-stage
-      - uses: actions/upload-artifact@v2
-        with:
-          node-version: 16
 
   deploy-sam:
     name: Deploy Serveless API
@@ -28,9 +28,9 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-    - run: |
-        working-directory: backend
+    - name: Deploy
+      working-directory: backend
+      run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file ./packaged.yaml --stack-name energy --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2
-        

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -2,13 +2,24 @@ name: SAM Deployment
 on:
   push:
     branches:
-      - master
+      - ci-github-actions
 jobs:
+  run-npm-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: npm install and build
+        run: |
+          npm install
+          npm run build-stage
+      - uses: actions/upload-artifact@v2
+        with:
+          node-version: 16
+
   deploy-sam:
     name: Deploy Serveless API
     runs-on: ubuntu-latest
     steps:
-    - working-directory: backend
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
     - uses: aws-actions/setup-sam@v1
@@ -18,7 +29,8 @@ jobs:
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
     - run: |
+        working-directory: backend
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
-        sam deploy --template-file ./packaged.yaml --stack-name energy --capabilities CAPABILITY_IAM;
+        sam deploy --template-file ./packaged.yaml --stack-name energy --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2
         

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -19,10 +19,14 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-    - name: npm install and build
+    - name: npm install and build frontend
       run: |
           npm install
           npm run build-stage
+    - name: Build Backend
+      working-directory: backend
+      run: |
+        sam build --use-container
     - name: Deploy
       working-directory: backend
       run: |

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: aws-actions/setup-sam@v1
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 12
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with: 
+        github_token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-python@v2
     - uses: aws-actions/setup-sam@v1
     - uses: actions/setup-node@v3
@@ -33,5 +35,3 @@ jobs:
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2
-      with: 
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -30,11 +30,6 @@ jobs:
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
-        sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --capabilities CAPABILITY_IAM --region us-west-2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: us-west-2
     - name: deploy frontend
       run: |
         aws s3 sync ./dist s3://energy-dashboard

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -2,7 +2,7 @@ name: SAM Deployment
 on:
   push:
     branches:
-      - ci-github-actions
+      - master
 jobs:
   deploy-sam:
     name: Deploy Serveless API
@@ -13,24 +13,14 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
     - uses: actions/setup-python@v2
     - uses: aws-actions/setup-sam@v1
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 12
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
-    - name: npm install and build frontend
-      run: |
-          npm install
-          npm run build-stage
     - name: Deploy
       working-directory: backend
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file /home/runner/work/energy-dashboard/energy-dashboard/backend/packaged.yaml --stack-name energy --no-confirm-changeset --no-fail-on-empty-changeset
-    - name: deploy frontend
-      run: |
-        aws s3 sync ./dist s3://energy-dashboard

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -12,6 +12,8 @@ jobs:
     - uses: actions/setup-python@v2
     - uses: aws-actions/setup-sam@v1
     - uses: actions/setup-node@v3
+      with:
+        node-version: 16
     - uses: aws-actions/configure-aws-credentials@v1
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -26,4 +28,4 @@ jobs:
       run: |
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
-        sam deploy --template-file ./packaged.yaml --stack-name energy --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2
+        sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -1,0 +1,24 @@
+name: SAM Deployment
+on:
+  push:
+    branches:
+      - master
+jobs:
+  deploy-sam:
+    name: Deploy Serveless API
+    runs-on: ubuntu-latest
+    steps:
+    - working-directory: backend
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v2
+    - uses: aws-actions/setup-sam@v1
+    - uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+    - run: |
+        sam validate
+        sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
+        sam deploy --template-file ./packaged.yaml --stack-name energy --capabilities CAPABILITY_IAM;
+        

--- a/.github/workflows/API-deploy.yml
+++ b/.github/workflows/API-deploy.yml
@@ -33,3 +33,5 @@ jobs:
         sam validate
         sam package --template-file template.yaml --s3-bucket osu-so-serverless-builds --output-template-file packaged.yaml
         sam deploy --template-file ./packaged.yaml --stack-name energy --no-fail-on-empty-changeset --s3-bucket energy-dashboard --capabilities CAPABILITY_IAM --region us-west-2
+      with: 
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added workflow for deploying SAM by referencing [this AWS blog post](https://aws.amazon.com/blogs/compute/using-github-actions-to-deploy-serverless-applications/) and our old logic for deploying serverless apps in the [.travis.yml](https://github.com/OSU-Sustainability-Office/energy-dashboard/blob/master/.travis.yml).

We still will need to copy over the AWS keys and create a workflow for our test build & unit tests for pull-requests to fully re-build our prior CI setup. 