### PR TITLE
fix sorting nan blocks at the bottom

### DIFF
--- a/src/components/campaigns/campaign_building_list.vue
+++ b/src/components/campaigns/campaign_building_list.vue
@@ -75,12 +75,9 @@ export default {
             const bPercentage = this.accumulatedPercentage(b.path)
             if (isNaN(aPercentage) && !isNaN(bPercentage)) {
               return 1
-            } else if (!isNaN(aPercentage) && isNaN(bPercentage))  {
+            } else if (isNaN(aPercentage) || isNaN(bPercentage)) {
               return -1
-            } else if (isNaN(aPercentage) && isNaN(bPercentage)) {
-              return -1
-            }
-            else {
+            } else {
               return 1
             }
           } catch (error) {

--- a/src/components/campaigns/campaign_building_list.vue
+++ b/src/components/campaigns/campaign_building_list.vue
@@ -77,7 +77,10 @@ export default {
               return 1
             } else if (!isNaN(aPercentage) && isNaN(bPercentage))  {
               return -1
-            } else {
+            } else if (isNaN(aPercentage) && isNaN(bPercentage)) {
+              return -1
+            }
+            else {
               return 1
             }
           } catch (error) {


### PR DESCRIPTION
Clicking on a building with data (e.g. Poling Hall, as shown below) no longer causes the buildings with no data (Weatherford and ILLC) to randomly switch places. Check in localhost:8080/campaign/9
![image](https://user-images.githubusercontent.com/82061589/217612842-b92e9916-9b8c-4404-ae1f-197fc10fe9e9.png)
