### PR TITLE
[PR] Remove views console error and also My Dashboard from navbar

### DIFF
--- a/src/components/navBar.vue
+++ b/src/components/navBar.vue
@@ -12,7 +12,7 @@
           <el-menu-item index="map" :route='{path: "/map"}' ref='mapItem'>Map</el-menu-item>
           <el-menu-item index="buildings" :route='{path: "/buildings"}' ref='buildingItem'>Building List</el-menu-item>
           <el-menu-item index="campaigns" :route='{path: "/campaigns"}' ref='buildingItem'>Campaigns</el-menu-item>
-          <el-menu-item v-if='onid' index="dashboard" :route='{path: "/dashboard"}' ref='dashboardItem'>My Dashboard</el-menu-item>
+          <!--<el-menu-item v-if='onid' index="dashboard" :route='{path: "/dashboard"}' ref='dashboardItem'>My Dashboard</el-menu-item> -->
           <el-menu-item index="getStarted" :route='{path: "/getstarted"}' ref='getStartedItem'>Get Started</el-menu-item>
         </el-menu>
       </el-col>

--- a/src/store/user.module.js
+++ b/src/store/user.module.js
@@ -60,7 +60,7 @@ const actions = {
             store.commit('onid', data.onid)
             let edashData = await API.edashUser()
             store.commit('privilege', edashData.privilege)
-            await store.dispatch('loadViews', edashData.appData['energyDashboard'].views)
+            // await store.dispatch('loadViews', edashData.appData['energyDashboard'].views)
             // store.commit('alerts', edashData.alerts)
           }
           resolve(store.getters)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/82061589/228657486-954f2634-6ae5-40c8-a443-853076bfef5f.png)
For some reason it says "My Dashboard" when logged in via some other OSU app, e.g. with Carbon Calculator. Since we haven't / don't plan to implement admin interface on energy dashboard, we should remove this. I commented out for now.

![image](https://user-images.githubusercontent.com/82061589/228657712-e7891354-8673-424b-af04-8cd026ec047d.png)
It also says something about "views" in console, probably also related to login. I commented out for now.