### PR TITLE
see if this shows test campaign only on local

### DIFF
--- a/src/components/campaigns/campaign_list.vue
+++ b/src/components/campaigns/campaign_list.vue
@@ -45,6 +45,10 @@ export default {
         this.currentCampaigns.push(camp)
       } else if (!camp.name.toLowerCase().startsWith('test')) {
         this.pastCampaigns.push(camp)
+      } else if (this.checkDate(camp.dateEnd) && camp.name.toLowerCase().startsWith('test') && process.env.VUE_APP_HOST_ADDRESS === 'http://localhost:8080') {
+        this.currentCampaigns.push(camp)
+      } else if (camp.name.toLowerCase().startsWith('test') && process.env.VUE_APP_HOST_ADDRESS === 'http://localhost:8080') {
+        this.pastCampaigns.push(camp)
       }
     }
     this.currentCampaigns.sort((a, b) => { return (new Date(b.dateEnd)).getTime() - (new Date(a.dateEnd)).getTime() })


### PR DESCRIPTION
If campaign starts with word "test", then it's only shown on localhost:8080.

This saves the effort of actually toggling the campaign name in MySQL workbench.

Tested to work on the test s3 build: http://energy-dashboard.s3-website-us-west-2.amazonaws.com/#/campaigns

## Future Possibilities
If in the future there is interest in also showing hidden buildings on localhost, we can change the `if (!state[key].hidden)`  statements at [line 171](https://github.com/OSU-Sustainability-Office/energy-dashboard/blob/master/src/store/map.module.js#L171) and also [line 182](https://github.com/OSU-Sustainability-Office/energy-dashboard/blob/master/src/store/map.module.js#L182) of `src/store/map.module.js` to check for `process.env.VUE_APP_HOST_ADDRESS`.

At present I think this is unnecessary, it isn't too hard to query the corresponding buildings in MySQL, e.g. `select * from data where meter_id = <id>  order by time DESC`

Meter ID of hidden buildings (future reference)

West Dining: 46
Weniger: 35
Orchard: N/A
Agriculture: 117
Weatherford: 120 (not connected to buildings table)
OSU Operations: 121 & 122