### PR TITLE
fix non solar edit buttons

### DIFF
--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -3,7 +3,7 @@
   Info: Displays a single chart for a dataset from the "buildings" directory.
 -->
 <template>
-  <div class="card-iframe" ref='card' v-if = "this.path === 'map/building_35/block_175' || 'map/building_36/block_176' || 'map/building_37/block_177' || 'map/building_38/block_178'">
+  <div class="card-iframe" ref='card' v-if = "this.path === ('map/building_35/block_175' || 'map/building_36/block_176' || 'map/building_37/block_177' || 'map/building_38/block_178')">
       <el-row :span='24' class='title' ref='title'>
         <el-col :span='20'>{{ name }}</el-col>
       </el-row>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/82061589/232595219-9a50adff-24d5-4d86-8e95-16cd0dccf0b0.png)


Fix the Edit buttons for non-solar buildings (forgot to surround list of solar buildings with parenthethes).