### PR TITLE
[PR] comparison menu misc bug fixes

### DIFF
--- a/src/components/map/map_prompt.vue
+++ b/src/components/map/map_prompt.vue
@@ -42,7 +42,7 @@ export default {
 <style lang="scss" scoped>
 .stage_prompt {
   width: 400px;
-  height: 170px;
+  height: 150px;
   position: absolute;
   top: 20px;
   left: calc(50% - 200px);
@@ -53,7 +53,7 @@ export default {
 }
 .text {
   padding: 1.5em;
-  font-size: 20px;
+  font-size: 18px;
 }
 .button {
   border: solid 1px $--color-white;
@@ -71,7 +71,7 @@ export default {
     top: 100px;
     width: 330px;
     left: 250px;
-    height: 180px;
+    height: 190px;
   }
 }
 </style>

--- a/src/components/map/map_prompt.vue
+++ b/src/components/map/map_prompt.vue
@@ -11,7 +11,7 @@
     <el-col :span="24">
       <el-row>
         <el-col class="text">
-          Select buildings to compare. <br /><br />
+          Select buildings by clicking on map or using building menu search bar. <br /><br />
           <el-row>NOTE: Only buildings with Electricity data are valid for comparison!</el-row>
         </el-col>
       </el-row>
@@ -42,7 +42,7 @@ export default {
 <style lang="scss" scoped>
 .stage_prompt {
   width: 400px;
-  height: 150px;
+  height: 170px;
   position: absolute;
   top: 20px;
   left: calc(50% - 200px);
@@ -68,7 +68,7 @@ export default {
 }
 @media only screen and (max-width: 600px) {
   .stage_prompt {
-    top: 80px;
+    top: 100px;
     width: 330px;
     left: 250px;
     height: 180px;

--- a/src/components/map/map_prompt.vue
+++ b/src/components/map/map_prompt.vue
@@ -71,7 +71,7 @@ export default {
     top: 100px;
     width: 330px;
     left: 250px;
-    height: 190px;
+    height: 200px;
   }
 }
 </style>


### PR DESCRIPTION
Fixes for Compare tool:
- selecting non-electric buildings now triggers error component correctly, regardless of order in selecting buildings
- buildings with some but not all non-electric data are now compatible with compare tool
- markers no longer become un-removable if you click "cancel" on compare tool before removing markers
- can now add buildings to comparison array from building menu search bar
- clearing search input now removes tooltips from search