### PR TITLE
Fixed map name discrepancy

### DIFF
--- a/src/components/map/map.vue
+++ b/src/components/map/map.vue
@@ -205,7 +205,7 @@ export default {
             this.polyClick( e.target.feature.properties.id, e.target.feature, layer.getBounds().getCenter() )
           } )
           layer.on( 'mouseover', e => {
-            if ( !e.target.setStyle ) return 
+            if ( !e.target.setStyle ) return
             e.target.oldStyle = {
               fillColor: e.target.options.fillColor,
               color: e.target.options.color
@@ -634,9 +634,7 @@ export default {
       var searchGroup = []
       for ( let layer of Object.values( this.map._layers ) ) {
         if ( layer.feature && layer.feature.geometry && layer.feature.geometry.type === 'Polygon' ) {
-          if ( layer.feature.id === 'way/1100972272' ) {
-            layer.feature.properties.name = 'OSU Operations'
-          }
+          layer.feature.properties.name = this.$store.getters['map/building']( layer.feature.properties.id ).name
 
           if ( layer.feature.properties.name !== undefined ) {
             if ( layer.feature.properties.name.toLowerCase().includes( v.toLowerCase() ) ) {

--- a/src/components/map/map.vue
+++ b/src/components/map/map.vue
@@ -204,17 +204,14 @@ export default {
             this.building_compare_error = false
             this.polyClick( e.target.feature.properties.id, e.target.feature, layer.getBounds().getCenter() )
           } )
-          layer.on( 'mouseover', function ( e ) {
-            if ( !e.target.setStyle ) return
-            if ( e.target.feature.id === 'way/1100972272' ) {
-              e.target.feature.properties.name = 'OSU Operations'
-            }
+          layer.on( 'mouseover', e => {
+            if ( !e.target.setStyle ) return 
             e.target.oldStyle = {
               fillColor: e.target.options.fillColor,
               color: e.target.options.color
             }
             e.target.setStyle( { fillColor: '#000', color: '#000' } )
-            e.target.bindTooltip( e.target.feature.properties.name ).openTooltip()
+            e.target.bindTooltip( this.$store.getters['map/building']( e.target.feature.properties.id ).name ).openTooltip()
           } )
           layer.on( 'mouseout', e => {
             if ( !e.target.setStyle ) return


### PR DESCRIPTION
Used buildings getter to pull building name from database instead of from Openstreetmap. This fixed the Arnold Cafeteria vs Arnold Dining Hall issue, as well as removed the need for hardcoding 'OSU Operations' building name.