### PR TITLE
Fixed FullScreen comparison bug

### DIFF
--- a/src/components/map/map.vue
+++ b/src/components/map/map.vue
@@ -362,19 +362,18 @@ export default {
       try {
         if (this.building_compare_error === false) {
           let path = this.$store.getters['map/building'](this.compareStories[0]).path
+          let mgId = this.$store.getters[path + '/primaryGroup']('Electricity').id
+          let blockSpace = this.$store.getters[path + '/block'](mgId).path
+          await this.$store.dispatch(blockSpace + '/removeAllModifiers')
+          await this.$store.dispatch(blockSpace + '/addModifier', 'building_compare')
+          await this.$store.dispatch(blockSpace + '/updateModifier', {
+            name: 'building_compare',
+            data: {
+              buildingIds: this.compareStories
+            }
+          })
 
           if (target === 'q') {
-            let mgId = this.$store.getters[path + '/primaryGroup']('Electricity').id
-
-            let blockSpace = this.$store.getters[path + '/block'](mgId).path
-            await this.$store.dispatch(blockSpace + '/removeAllModifiers')
-            await this.$store.dispatch(blockSpace + '/addModifier', 'building_compare')
-            await this.$store.dispatch(blockSpace + '/updateModifier', {
-              name: 'building_compare',
-              data: {
-                buildingIds: this.compareStories
-              }
-            })
             window.vue.$store.dispatch('modalController/openModal', {
               name: 'map_compare_side',
               path: path


### PR DESCRIPTION
Clicking on the "Compare in FullScreen" dropdown when a non-electricity building is selected causes various issues. 

![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/2b68f8df-4cbe-4350-9f81-5662f8e04c6a)

Comparing in FullScreen when only one non-electricity building is selected or two non-electricity buildings are selected
---
It gets stuck on a blank page with type errors in the console

![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/b7fcbdee-9d3d-42c8-9a04-03e392db9dba)

Comparing in FullScreen when a non-electricity and an electricity building are selected
---
If the non-eletricity building is clicked first, it does the same as above, but if the electricity building is selected first, it tries to compare them but can't bring up a chart for the non-electricity building

![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/7b4aa873-d924-46ec-8cd2-adfe448e4a46)

Code
---
Moving only lines 367 - 371 above the if-statement fixed it only when the non-electricity building was selected first, but moving the updateModifier logic above fixed the issue when an electric building is selected first.