### PR TITLE
Fixed Meter change issue

### DIFF
--- a/src/components/view/modals/edit_card.vue
+++ b/src/components/view/modals/edit_card.vue
@@ -117,7 +117,7 @@
           ref="submeters"
           v-model="form.sets[currentIndex].meter"
           style="width: 100%"
-          @change="form[currentIndex].point = null"
+          @change="form.sets[currentIndex].point = meterPoints[0].value"
         >
           <el-option v-for="item in meters" :key="item.path" :label="item.name" :value="item.path"></el-option>
         </el-select>
@@ -214,7 +214,7 @@
               ref="submeters"
               v-model="form.sets[currentIndex].meter"
               style="width: 100%"
-              @change="form[currentIndex].point = null"
+              @change="form.sets[currentIndex].point = meterPoints[0].value"
             >
               <el-option v-for="item in meters" :key="item.path" :label="item.name" :value="item.path"></el-option>
             </el-select>


### PR DESCRIPTION
There was a typo in two places that was throwing an error in the console whenever you switch the Meter type (from steam to electricity for example). In addition to that, it was defaulting the Measurement to a value that would cause issues if the user just hit "ok" instead of changing the value to a valid one. 

![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/d9d79481-d1af-47f1-8702-2a20c3ce5a0e)


Fixing the typo `form[currentIndex].point = null` to `form.sets[currentIndex].point = null` would clear the Measurement input completely after switching the Meter type, but this would not throw any errors and would still allow the user to hit "ok" and try to send the request, which would fail. 

I changed it so that when the Meter type is changed, the Measurement is set to whatever the first Measurement type is for that Meter type. The measurement can still be changed with the dropdown, but now if the user only changes the Meter and hits "ok" it will load a valid chart. This seems to work for all Meter changes between Steam, Electric, Solar, and Gas. 