### PR TITLE
Push Meter Class Changes to Prod

### DIFF
--- a/backend/dependencies/nodejs/meter_classes.js
+++ b/backend/dependencies/nodejs/meter_classes.js
@@ -160,5 +160,9 @@ module.exports = {
     1: 'voltage',
     2: 'energy_change',
     3: 'total_energy'
+  },
+  9990002: {
+    // Pacific Power Meters
+    4: 'accumulated_real'
   }
 }


### PR DESCRIPTION
basically [this part of dependencies/nodejs/meter.js file](https://github.com/OSU-Sustainability-Office/energy-dashboard/blob/master/backend/dependencies/nodejs/models/meter.js#L112) bugs out if it can't find the meter class, and allBuildings API call calls all the meters connected to a meter group connected to a building, so that was why allBuildings API call was timing out on prod earlier today.

So I just move meter class changes from https://github.com/OSU-Sustainability-Office/energy-dashboard/pull/302 into prod for now.

![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/002b3bec-cb2d-4c0c-bf15-0067739365aa)

Another approach would be to buildings with "hidden" attribute from the allBuildings API call
(e.g. https://github.com/OSU-Sustainability-Office/energy-dashboard/blob/master/backend/dependencies/nodejs/models/building.js#L225), but I don't know if that would make it too difficult to test frontend of newly added buildings locally.