### PR TITLE
Handle multiple meters per meter group for Solar

### DIFF
--- a/src/store/meter_group.module.js
+++ b/src/store/meter_group.module.js
@@ -94,6 +94,10 @@ const actions = {
       payload.point !== 'accumulated_real' &&
       payload.point !== 'total' &&
       payload.point !== 'cubic_feet' &&
+
+      // PacificPower meters are accumulated_real by the time they get here,
+      // but may as well handle solar meters in the future anyways
+      payload.point !== 'energy_change' &&
       store.getters.meters.length > 1
     ) {
       // && store.getters.meters.length > 1) {


### PR DESCRIPTION
It seems that by the time PacificPower meters get to meter_group.js file, they are accumulated_real measurement type anyways.

However, it could be good to handle case for solar meters in the future regardless.

![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/c1d0ecaa-8024-41ba-abf9-0cbd115ccee2)

Other notes for adding multiple meters to Radiation Center meter group:
(This may be a good indication of future potential issues of supporting multiple-meter meter groups with solar energy type, since PacificPower uses energy_change initially)

- Measurement type is accumulated_real by the time it reaches src/store/meter_group.js, so multiple meters can be combined into one meter group for PacificPower meters without any issue
- Adding up accumulated_real values for various days seemed to sum up values from 3 meters as expected, and Inspect Element > Network makes 3 API calls at https://dashboard.sustainability.oregonstate.edu/#/building/59/2
  - For February 15 (Unix: 1708041599), meters 129 and 139 have data while meter 148 does not. As expected, the accumulated_real value shown for February 15 (for the Radiation Center meter group) is the sum of meters 129 and 139 only.