### PR TITLE
Fix x-axis ticks to reflect hourly and 15-minute intervals

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_ROOT_API=http://localhost:3000
+VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
+VUE_APP_ROOT_API=http://localhost:3000
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/src/components/charts/chartController.vue
+++ b/src/components/charts/chartController.vue
@@ -415,7 +415,7 @@ export default {
               case 'hour':
               case 'minute':
                 date =
-                  date.toLocaleDateString('en-US', { month: 'numeric', day: '2-digit' }) +
+                  date.toLocaleDateString('en-US', { weekday: 'short' }).substring(0, 2) +
                   ' ' +
                   date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
                 break

--- a/src/components/charts/chartController.vue
+++ b/src/components/charts/chartController.vue
@@ -394,6 +394,8 @@ export default {
     // this is called when there are multiple time period charts, it returns an array of all the
     // chart dates for that index so that they can be displayed on multiple lines
     buildXaxisTick (index) {
+      const interval = this.$store.getters[this.path + '/intervalUnit']
+
       if (this.chartData.datasets) {
         let tick = []
         for (let chart of this.chartData.datasets) {
@@ -401,9 +403,25 @@ export default {
 
           if (chart.data[index]) {
             if (chart.data[index].originalX) {
-              date = chart.data[index].originalX.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+              date = chart.data[index].originalX
             } else {
-              date = chart.data[index].x.toLocaleDateString('en-US', { month: 'numeric', day: 'numeric' })
+              date = chart.data[index].x
+            }
+
+            switch (interval) {
+              case 'day':
+                date = date.toLocaleDateString('en-US', { month: 'numeric', day: '2-digit' })
+                break
+              case 'hour':
+              case 'minute':
+                date =
+                  date.toLocaleDateString('en-US', { month: 'numeric', day: '2-digit' }) +
+                  ' ' +
+                  date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+                break
+              case 'month':
+                date = date.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+                break
             }
           }
 

--- a/src/components/charts/linechart.js
+++ b/src/components/charts/linechart.js
@@ -164,12 +164,12 @@ export default {
                 fontFamily: 'Open Sans'
               },
               time: {
-                unit: 'day',
+                unit: this.$parent.$store.getters[this.$parent.path + '/intervalUnit'],
                 unitStepSize: 15,
                 displayFormats: {
                   day: 'M/DD',
                   hour: 'dd h:mm a',
-                  minute: 'h:mm a'
+                  minute: 'dd h:mm a'
                 }
               }
             }

--- a/src/components/charts/linechart.js
+++ b/src/components/charts/linechart.js
@@ -147,7 +147,7 @@ export default {
                 source: 'data',
                 // the following three settings change the x-ticks if there are multiple time periods,
                 // otherwise the default settings are used
-                autoSkipPadding: this.$parent.multipleTimePeriods(this.$parent.chartData.datasets) ? 10 : 3,
+                autoSkipPadding: this.$parent.multipleTimePeriods(this.$parent.chartData.datasets) ? 15 : 3,
                 maxRotation: this.$parent.multipleTimePeriods(this.$parent.chartData.datasets) ? 0 : 50,
                 callback: (val, index) => {
                   if (this.$parent.multipleTimePeriods(this.$parent.chartData.datasets)) {

--- a/src/components/map/sideView.vue
+++ b/src/components/map/sideView.vue
@@ -180,8 +180,8 @@ export default {
   z-index: 401;
   display: block;
   position: absolute;
+  bottom: 14%;
   left: 29.5%;
-  bottom: 13%;
   width: 420px !important;
   height: 85% !important;
 }
@@ -208,14 +208,14 @@ export default {
   cursor: pointer;
 }
 .media {
-  height: 200px;
+  height: 150px;
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
   border-bottom: solid 1px #fff;
 }
 .graphcontrol {
-  padding: 1.5em;
+  padding: 1em;
 }
 .rangeButtonParent {
   padding: 0.2em;

--- a/src/components/map/sideView.vue
+++ b/src/components/map/sideView.vue
@@ -37,7 +37,7 @@
                   'margin-right': '10px',
                   'margin-left': '10px'
                 }"
-                :height="200"
+                :height="250"
                 :invertColors="true"
               />
             </el-col>


### PR DESCRIPTION
Hourly/15-minute Interval Before
---
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/bc6dcda1-3367-490e-94f1-77da6112b8bb)

Both hourly and 15-minute intervals would only display the day on the x-axis

Hourly/15-minute Interval After
---
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/c2dfc958-06b8-40fd-86d1-bd3b39d63ba5)
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/c11fb2cd-d899-4bfe-b7df-05bce0b48d17)

The new hourly interval is displayed in the bottom picture. 

The 15-minute interval displayed in the top picture now shows the day of the week and the time, which is every 30-minutes here due to having ~2 1/2 days of data displayed. I added formatting to the 'minute' option so that the day is visible, otherwise the data is hard to read as displayed here, without the update:
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/666bb3e0-74ee-483f-bda7-7554189dfba7)

Monthly Interval
---
One side effect of this change is that the monthly interval labels are now `Month Year` instead of `Month / Day`:

Before:
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/aacd55cf-3b2c-471a-8dfc-3e4809720bd5)

After:
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/78caebb8-ca4c-4765-8e05-91a39e36f024)

This can easily be changed by adding a formatting rule for the month interval if the previous format is preferred. 