### PR TITLE
fixed bar chart not loading for campaign single building view

### DIFF
--- a/src/components/charts/chartController.vue
+++ b/src/components/charts/chartController.vue
@@ -353,7 +353,7 @@ export default {
       }
     },
     multipleTimePeriods: function (charts) {
-      if (charts.length > 1 && charts[0].multStart.length > 1) {
+      if (charts.length > 1 && charts[0].multStart && charts[0].multStart.length > 1) {
         return true
       }
       return false


### PR DESCRIPTION
- Issue was that the charts for this view do not have a "multStart", so it was trying to read an undefined value