### PR TITLE
Pacific Power exclusion endpoint

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_ROOT_API=http://localhost:3000
+VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
+VUE_APP_ROOT_API=http://localhost:3000
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/backend/app/pacific_power_exclusion.js
+++ b/backend/app/pacific_power_exclusion.js
@@ -23,7 +23,7 @@ exports.post = async (event, context) => {
     response.body = JSON.stringify(await new PacificPowerExclusion().add(meterID))
   } catch (error) {
     response.body = error.message
-    response.status = 400
+    response.statusCode = 400
   }
   return response
 }

--- a/backend/app/pacific_power_exclusion.js
+++ b/backend/app/pacific_power_exclusion.js
@@ -1,0 +1,8 @@
+const Response = require('/opt/nodejs/response.js')
+const PacificPowerExclusion = require('/opt/nodejs/models/pacific_power_exclusion.js')
+
+exports.get = async (event, context) => {
+  let response = new Response(event)
+  response.body = JSON.stringify(await new PacificPowerExclusion().get())
+  return response
+}

--- a/backend/app/pacific_power_exclusion.js
+++ b/backend/app/pacific_power_exclusion.js
@@ -6,3 +6,24 @@ exports.get = async (event, context) => {
   response.body = JSON.stringify(await new PacificPowerExclusion().get())
   return response
 }
+
+exports.post = async (event, context) => {
+  let response = new Response(event)
+
+  const payload = JSON.parse(event.body)
+  const pwd = payload['pwd']
+  const meterID = payload['id']
+
+  if (pwd !== process.env.ACQUISUITE_PASS || !meterID) {
+    response.statusCode = 400
+    return response
+  }
+
+  try {
+    response.body = JSON.stringify(await new PacificPowerExclusion().add(meterID))
+  } catch (error) {
+    response.body = error.message
+    response.status = 400
+  }
+  return response
+}

--- a/backend/dependencies/nodejs/models/pacific_power_exclusion.js
+++ b/backend/dependencies/nodejs/models/pacific_power_exclusion.js
@@ -1,0 +1,10 @@
+const DB = require('/opt/nodejs/sql-access.js')
+
+class PacificPowerExclusion {
+  async get() {
+    await DB.connect()
+    return DB.query(`SELECT * FROM pacific_power_exclusion`)
+  }
+}
+
+module.exports = PacificPowerExclusion

--- a/backend/dependencies/nodejs/models/pacific_power_exclusion.js
+++ b/backend/dependencies/nodejs/models/pacific_power_exclusion.js
@@ -5,6 +5,15 @@ class PacificPowerExclusion {
     await DB.connect()
     return DB.query(`SELECT * FROM pacific_power_exclusion`)
   }
+
+  async add(meterID) {
+    await DB.connect()
+    return DB.query(`INSERT INTO pacific_power_exclusion (pp_meter_id, status, date_added) VALUES (?, ?, ?)`, [
+      meterID,
+      'new',
+      new Date().toISOString()
+    ])
+  }
 }
 
 module.exports = PacificPowerExclusion

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -733,6 +733,21 @@ Resources:
           Properties:
             Path: /ppexclude
             Method: get
+  ppUpload:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 128
+      CodeUri: app/
+      Handler: pacific_power_exclusion.post
+      Layers:
+        - !Ref LambdaCommonLayer
+        - !Ref EnergyModelLayer
+      Events:
+        Building:
+          Type: Api
+          Properties:
+            Path: /ppupload
+            Method: post
   EnergyModelLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -13,11 +13,11 @@ Globals:
     # enable CORS; to make more specific, change the origin wildcard
     # to a particular domain name, e.g. "'www.example.com'"
     Cors:
-        AllowMethods: "'POST, GET'"
-        AllowHeaders: "'X-Forwarded-For'"
-        AllowOrigin: "'oregonstate.edu'"
-        MaxAge: "'600'"
-        AllowCredentials: True
+      AllowMethods: "'POST, GET'"
+      AllowHeaders: "'X-Forwarded-For'"
+      AllowOrigin: "'oregonstate.edu'"
+      MaxAge: "'600'"
+      AllowCredentials: True
     BinaryMediaTypes:
       - image~1gif
       - image~1png
@@ -26,20 +26,20 @@ Globals:
       - multipart/form-data
   HttpApi:
     CorsConfiguration:
-        AllowMethods:
-          - GET
-          - POST
-        AllowHeaders: 
-          - "'X-Forwarded-For'"
-        AllowOrigins:
-          - "https://dashboard.sustainability.oregonstate.edu"
-        MaxAge: 600
-        AllowCredentials: True
+      AllowMethods:
+        - GET
+        - POST
+      AllowHeaders:
+        - "'X-Forwarded-For'"
+      AllowOrigins:
+        - 'https://dashboard.sustainability.oregonstate.edu'
+      MaxAge: 600
+      AllowCredentials: True
 Parameters:
   LambdaCommonLayer:
     Type: String
     Default: arn:aws:lambda:us-west-2:005937143026:layer:LambdaCommonLayer:97
-    
+
 Resources:
   test:
     Type: AWS::Serverless::Function
@@ -238,7 +238,7 @@ Resources:
     Properties:
       Timeout: 30
       MemorySize: 256
-      CodeUri:  app/
+      CodeUri: app/
       Handler: meter.batchData
       Layers:
         - !Ref LambdaCommonLayer
@@ -718,18 +718,33 @@ Resources:
           Properties:
             Path: /admin/devices
             Method: get
+  ppExclude:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 128
+      CodeUri: app/
+      Handler: pacific_power_exclusion.get
+      Layers:
+        - !Ref LambdaCommonLayer
+        - !Ref EnergyModelLayer
+      Events:
+        Building:
+          Type: Api
+          Properties:
+            Path: /ppexclude
+            Method: get
   EnergyModelLayer:
-        Type: AWS::Serverless::LayerVersion
-        Properties:
-            LayerName: EnergyModelLayer
-            Description: DB Model Defs
-            ContentUri: dependencies/
-            CompatibleRuntimes:
-              - nodejs6.10
-              - nodejs8.10
-              - nodejs10.x
-              - nodejs12.x
-              - nodejs16.x
-              - nodejs18.x
-            LicenseInfo: 'MIT'
-            RetentionPolicy: Retain
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      LayerName: EnergyModelLayer
+      Description: DB Model Defs
+      ContentUri: dependencies/
+      CompatibleRuntimes:
+        - nodejs6.10
+        - nodejs8.10
+        - nodejs10.x
+        - nodejs12.x
+        - nodejs16.x
+        - nodejs18.x
+      LicenseInfo: 'MIT'
+      RetentionPolicy: Retain


### PR DESCRIPTION
Added an endpoint to retrieve all Pacific Power Meters in the `pacific_power_exclusion` table of the database. 

See also:
https://github.com/OSU-Sustainability-Office/energy-dashboard/issues/313
https://github.com/OSU-Sustainability-Office/automated-jobs/issues/47


Testing
---
* Run backend locally (`sam local start-api` from backend directory)
* Visit http://http://localhost:3000/ppexclude
* There are only two meters in the database for now, one to be excluded and one to be included
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/102624422/8f7b9111-1283-450a-8b6d-1746357b081e)

TODO
---
* Update PacificPower scraper in automated-jobs repo to retrieve exclusion list and use it to decide whether or not to upload data for each meter
  * If a meter is not on the exclusion list, that means it's a new meter, update scraper to add meter with `exclude` field of `new`
* Add endpoint for adding a new meter to the database with `new` in `exclude` field
* Cloudwatch alert for any new meters added
* Add all existing Pacific Power meters to the table (I am holding off on this for now to make sure we want the current table/naming structure)