### PR TITLE
poling campaign fix

### DIFF
--- a/src/store/chart_modifiers/line_bar/baseline_perc.js
+++ b/src/store/chart_modifiers/line_bar/baseline_perc.js
@@ -38,19 +38,8 @@ export default class LinePercModifier {
   */
   async postGetData (chartData, payload, store, module) {
     let resultDataObject = chartData.data
-
-    // array that stores keys for the resultDataObject (used for finding nearest valid keys for Weatherford)
-    let keysarray = Array.from(resultDataObject.keys())
     let returnData = []
     let delta = 1
-
-    // Finds the nearest valid keys for a given building (mostly intended for correcting manual meter uploads, e.g. Weatherford.)
-    // Other buildings with automatic meter upload should have the same keys after this function is run.
-    function findClosest (array, num) {
-      return array.reduce(function (prev, curr) {
-        return Math.abs(curr - num) < Math.abs(prev - num) ? curr : prev
-      })
-    }
 
     switch (payload.intervalUnit) {
       case 'minute':
@@ -72,8 +61,6 @@ export default class LinePercModifier {
     let differenceBaseline = new Map()
 
     for (let i = payload.compareStart; i <= payload.compareEnd; i += delta) {
-      // let result2 = findClosest(keysarray2, (delta + i));
-      // let result_i2 = findClosest(keysarray2, (i));
       try {
         if (isNaN(baselineData.get(i + delta)) || isNaN(baselineData.get(i))) {
           continue
@@ -116,33 +103,20 @@ export default class LinePercModifier {
 
     for (let i = payload.dateStart; i <= payload.dateEnd; i += delta) {
       let accumulator = 0
-      let result
-      let result_delta
-      let result_i
 
-      // If array is empty, don't use the nearest valid index algorithm (needed for past 6 hours / past day on Weatherford)
-      if (keysarray === undefined || keysarray.length === 0) {
-        result = delta + i
-        result_delta = delta
-        result_i = i
-      } else {
-        result = findClosest(keysarray, delta + i)
-        result_delta = findClosest(keysarray, delta)
-        result_i = findClosest(keysarray, i)
-      }
       try {
-        if (isNaN(resultDataObject.get(result)) || isNaN(resultDataObject.get(result_i))) {
+        if (isNaN(resultDataObject.get(delta + i)) || isNaN(resultDataObject.get(i))) {
           continue
         }
         let baselinePoint =
-          avgbins[new Date(result * 1000).getDay()][Math.floor((result % (60 * 60 * 24)) / result_delta)]
+          avgbins[new Date((delta + i) * 1000).getDay()][Math.floor(((delta + i) % (60 * 60 * 24)) / delta)]
         if (baselinePoint !== -1) {
-          accumulator = ((resultDataObject.get(result) - resultDataObject.get(result_i)) / baselinePoint) * 100 - 100
+          accumulator = ((resultDataObject.get(delta + i) - resultDataObject.get(i)) / baselinePoint) * 100 - 100
 
           // do not add data point to graph if datapoint is -100% (issue with Weatherford for campaign 8, near the end)
           if (accumulator !== -100) {
             // line below has something to do with the graph with all buildings on it
-            returnData.push({ x: new Date(result * 1000), y: accumulator })
+            returnData.push({ x: new Date((delta + i) * 1000), y: accumulator })
           }
         }
       } catch (error) {


### PR DESCRIPTION
## Issue
- https://github.com/OSU-Sustainability-Office/energy-dashboard/issues/318
- Poling Hall (as of April 22, 2024) shows percentages of 400 or 500% energy savings (implausibly high), as shown below
- This is related to [this old PR](https://github.com/OSU-Sustainability-Office/energy-dashboard/pull/216/files) from last year
  - The objective of that PR was to try to fix Weatherford from the 2022 campaign to show up, which might also lead to the possibility of supporting manually uploading data for a particular building in a campaign (the original issue with Weatherford was that because the data was manually uploaded in SQL, the data was only uploaded in hourly increments while the database expected 15 minute values)
  - However, the findClosest function (at least in `baseline_perc.js` file) is not working as expected (you can see my old comments in this file about something not working quite right for 1 day / 6 hours)
    - I couldn't get Weatherford to show up on the 1 day / 6 hours graphs of the 2022 campaign either (although that may just be due lack of Weatherford data on the last day of 2022 campaign)

## Potential Solutions
- **Option 1 (current)**: Just remove any references to `findClosest` function (and related variables etc) in `src\store\chart_modifiers\line_bar\baseline_perc.js` file
  - **It is not vital that Weatherford shows up on the 2022 campaign (and as mentioned above, it didn't seem to work for 1 day / 6 hours anyways), and if the Office wants to support manually uploaded campaign data in the future, that can be handled via a new and better fix in the future**
  - Fairly certain that `baseline_perc.js` file is only used by the campaigns, although that should be double checked
  - I don't think there are currently any issues with other files that use `findClosest` function (e.g. `accumulated_real.js`, `energy_change.js`)

- **Option 2**: Try to fix the logic for the `findClosest` function in the `baseline_perc.js` file
  - Probably not feasible unless a very simple fix is found within a day or two, since it is important to get the campaign online and in mostly-working order ASAP)

## Screenshots

### Before
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/373078b3-265f-4fed-9339-2ebadc5018c4)
- https://dashboard.sustainability.oregonstate.edu/#/campaign/12 (or test on local, master branch)

### After
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/d5573502-ca81-4486-89a2-308e4892fc0e)
- http://energy-dashboard.s3-website-us-west-2.amazonaws.com/#/campaign/12 (or test on local)
- As you can see, although there is a weird spike to 200% still, overall the values makes more sense
