### PR TITLE
Fix Merryfield

### DIFF
--- a/backend/dependencies/nodejs/models/meter.js
+++ b/backend/dependencies/nodejs/models/meter.js
@@ -137,7 +137,7 @@ class Meter {
         // get table name from meter table
         let [{ name: meter_table_name }] = await DB.query('SELECT `name` FROM meters WHERE id = ?', [this.id])
         const teslaMeterIds = ['83', '84', '85', '86', '118']
-        if (String(meterClass) === 999001 && teslaMeterIds.includes(String(this.id))) {
+        if (String(meterClass) === '9990001' && teslaMeterIds.includes(String(this.id))) {
           return DB.query(
             'SELECT ' +
               point +

--- a/backend/dependencies/nodejs/models/meter.js
+++ b/backend/dependencies/nodejs/models/meter.js
@@ -136,7 +136,8 @@ class Meter {
       if (String(meterClass).startsWith('999')) {
         // get table name from meter table
         let [{ name: meter_table_name }] = await DB.query('SELECT `name` FROM meters WHERE id = ?', [this.id])
-        if (meter_table_name.startsWith('M')) {
+        const teslaMeterIds = ['83', '84', '85', '86', '118']
+        if (String(meterClass) === 999001 && teslaMeterIds.includes(String(this.id))) {
           return DB.query(
             'SELECT ' +
               point +


### PR DESCRIPTION
## Fix Merryfield SQL Error
- Closes https://github.com/OSU-Sustainability-Office/energy-dashboard/issues/320

## Changes
- Fixed the "tesla meter check" to check from a fixed list of Tesla meters (given that we do not expect any new Tesla meters to be added), instead of checking for first letter "M"
- Issue was that Merryfield Hall (not Tesla) has a meter name starts with "M", triggering the Tesla logic by accident

## Future Considerations
- A better long term fix (maybe for another PR) is to figure out how to get the Tesla meter IFrames to display correctly without having to send an API call to Energy Dashboard Database
  - Setting meter_group ID to `null` causes the Tesla meter Iframes to disappear currently, so I assume that the "card" component (`src\components\view\card.vue`), which wraps around the charts on the building / map pages, checks meter group API call

## Screenshots
Verifying that both Merryfield and Tesla meters (example of 35th St. Array) load correctly on frontend (showing API calls succeeded)
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/14dc151d-9243-43c6-abae-0fd0eababc64)
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/5a94b866-4f29-44db-9f3a-a2a2d759e7c4)
