### PR TITLE
7th day timezone hotfix?

### DIFF
--- a/backend/dependencies/nodejs/models/pacific_power_recent.js
+++ b/backend/dependencies/nodejs/models/pacific_power_recent.js
@@ -2,26 +2,49 @@ const DB = require('/opt/nodejs/sql-access.js')
 
 class PacificPowerRecent {
   async get() {
-    // Get Unix TimeStamp for 11:59:59 PM GMT of 7 days ago
     await DB.connect()
-    const currentDate = new Date()
-    const date = new Date(currentDate)
-    date.setUTCHours(0)
-    date.setUTCMinutes(0)
-    date.setUTCSeconds(0)
-    date.setUTCMilliseconds(0)
-    const endTimestamp = Math.floor(date.getTime() / 1000) // End of today in seconds
 
-    date.setDate(date.getDate() - 7)
-    const startTimestamp = Math.floor(date.getTime() / 1000) // 7 days ago in seconds
+    // see automated-jobs/SEC/readSEC.js for original function
+    // Automatically detects the timezone difference of US Pacific vs GMT-0 (7 or 8 depending on daylight savings)
+    // https://stackoverflow.com/questions/20712419/get-utc-offset-from-timezone-in-javascript
+    const getOffset = timeZone => {
+      const timeZoneName = Intl.DateTimeFormat('ia', {
+        timeZoneName: 'shortOffset',
+        timeZone
+      })
+        .formatToParts()
+        .find(i => i.type === 'timeZoneName').value
+      const offset = timeZoneName.slice(3)
+      if (!offset) return 0
+
+      const matchData = offset.match(/([+-])(\d+)(?::(\d+))?/)
+      if (!matchData) throw `cannot parse timezone name: ${timeZoneName}`
+
+      const [, sign, hour, minute] = matchData
+      let result = parseInt(hour) * 60
+      if (sign === '+') result *= -1
+      if (minute) result += parseInt(minute)
+
+      return result
+    }
+
+    // Get Unix TimeStamp for 11:59:59 PM GMT of 7 days ago
+    const dateObjUnix = new Date(
+      // (days * hours * minutes * seconds * ms)
+      new Date().getTime() - (7 * 24 * 60 * 60 * 1000 + getOffset('US/Pacific') * 60 * 1000)
+    )
+
+    dateObjUnix.setUTCHours(23, 59, 59, 0)
+
+    const timestamp7DaysAgo = Math.floor(dateObjUnix.getTime() / 1000) // Convert milliseconds to seconds
 
     return DB.query(
       `SELECT MAX(time) as time, MAX(time_seconds) as time_seconds, pacific_power_meter_id 
       FROM pacific_power_data
-      WHERE time_seconds >= ? AND time_seconds <= ?
+      WHERE time_seconds >= ?
       GROUP BY pacific_power_meter_id, DATE(FROM_UNIXTIME(time_seconds))
       ORDER BY pacific_power_meter_id, time_seconds ASC;`,
-      [startTimestamp, endTimestamp]
+      [timestamp7DaysAgo]
     )
   }
 }


### PR DESCRIPTION
## Issue

For some reason the last data shown on ppRecent API endpoint (on master branch) was from May 4th instead of 3rd as expected, leading to errors:
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/a5c1717b-7b0e-4982-a4c9-5ec2237ccd75)
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/38c54102-da3d-46d0-8cfa-26d705ccdc97)

Pretty sure it's related to timezone (between 5 pm (4 pm during daylight savings) to 11:59 pm pst, the 7th day might be off by a day).

Not that it matters for the production version of webscraper running on AWS ECS, as it's running on a cron job at the same time of day, but this could help a lot for debug / local dev.

Copied function over from the timezone checking function we use for automated-jobs/SEC/readSEC.js etc.

Quick demo for testing: https://playcode.io/1866567