### PR TITLE
fix firefox active tab highlight bug

### DIFF
--- a/src/components/get_started/buildingListTab.vue
+++ b/src/components/get_started/buildingListTab.vue
@@ -22,7 +22,7 @@ export default {
     return {
       buildingPic: 'https://energy-dashboard.s3-us-west-2.amazonaws.com/images/buildingPic.jpg',
       buildingStep1:
-        'When you click on the "Building List" tab, the page will automatically show you all of the buildings in alphabetical order. Scroll through the list to find what you\'re looking for!',
+        'When you click on the "Buildings" tab, the page will automatically show you all of the buildings in alphabetical order. Scroll through the list to find what you\'re looking for!',
       buildingStep2: 'Click on a category to see what buildings are in each category.',
       buildingStep3:
         'You can type out a building name in the search bar. It must be spelled correctly for the building to show up.'

--- a/src/components/get_started/mainDescription.vue
+++ b/src/components/get_started/mainDescription.vue
@@ -7,7 +7,7 @@
     </el-row>
     <el-divider class="divider" content-position="left"> How To Use The "Map" Tab </el-divider>
     <mapTab />
-    <el-divider class="divider" content-position="left"> How To Use The "Building List" Tab </el-divider>
+    <el-divider class="divider" content-position="left"> How To Use The "Buildings" Tab </el-divider>
     <buildingListTab />
   </div>
 </template>

--- a/src/components/navBar.vue
+++ b/src/components/navBar.vue
@@ -6,7 +6,7 @@
         <ul class="nav-items">
           <li class="navLi"><router-link to="/map" class="navLink">Map</router-link></li>
           <li class="navLi">
-            <router-link to="/buildings" class="navLink">Building List</router-link>
+            <router-link to="/buildings" class="navLink">Buildings</router-link>
           </li>
           <li class="navLi">
             <router-link to="/campaigns" class="navLink">Campaigns</router-link>
@@ -87,8 +87,6 @@ i {
   padding-top: 28px;
   padding-right: 10px;
   padding-left: 10px;
-  margin-left: -10px;
-  margin-right: -10px;
 }
 .logo {
   padding-top: 10px;


### PR DESCRIPTION
## Issue
- Closes https://github.com/OSU-Sustainability-Office/energy-dashboard/issues/297

## Changes
- Removed `margin-left: -10px` and `margin-right: -10px` from navbar component, which was what caused the bug
- Also shortened "Building List" to just "Buildings", partly because the "Building List" text would render on 2 lines without negative margins (on mobile device resolutions, like 600px wide screen), and partly because it's not like we show "Campaign List" instead of "Campaigns
- Also replaced "Building List" with "Buildings" in the FAQ ("getting started") tab
- Actual component names or code comments referencing "building list" were not changed

## Screenshots

### PC Browser, Firefox
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/fea8c616-0861-487b-8301-dce960b6d9e8)

### Mobile Browser, Safari
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/04220816-98ab-4d97-8be3-f17b3ab8d237)
