### PR TITLE
fix solar / pp timeframe override and week label capitalization

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_ROOT_API=http://localhost:3000
+VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VUE_APP_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
+VUE_APP_ROOT_API=http://localhost:3000
 VUE_APP_HOST_ADDRESS=http://localhost:8080

--- a/src/components/view/modals/download_data.vue
+++ b/src/components/view/modals/download_data.vue
@@ -62,7 +62,7 @@ Saturday December 21st 2019 * @Copyright: (c) Oregon State University 2019 */
           <el-option :value="1" label="15 Minutes"></el-option>
           <el-option :value="2" label="1 Hour"></el-option>
           <el-option :value="3" label="1 Day"></el-option>
-          <el-option :value="4" label="1 week"></el-option>
+          <el-option :value="4" label="1 Week"></el-option>
           <el-option :value="5" label="1 Month"></el-option>
         </el-select>
       </el-form-item>

--- a/src/components/view/modals/edit_card.vue
+++ b/src/components/view/modals/edit_card.vue
@@ -82,7 +82,7 @@
           <el-option :value="1" label="15 Minutes"></el-option>
           <el-option :value="2" label="1 Hour"></el-option>
           <el-option :value="3" label="1 Day"></el-option>
-          <el-option :value="4" label="1 week"></el-option>
+          <el-option :value="4" label="1 Week"></el-option>
           <el-option :value="5" label="1 Month"></el-option>
         </el-select>
       </el-form-item>

--- a/src/components/view/view.vue
+++ b/src/components/view/view.vue
@@ -282,27 +282,12 @@ export default {
     },
     intervalUnit: {
       get () {
-        /*
-         If we're dealing with solar panels just show the interval in hours or minutes since the
-         default unit for solar panels is Energy in Interval--basically the change in
-         energy absorbed over a time frame, so any range greater than an hour will make ChartJS
-         produce a trendline of zero (horizontal line) which isn't particularly useful for anyone.
-        */
-        let isSolar = ''
-        if (this.$store.getters[`map/building_${this.$route.params.id}/meterGroups`]) {
-          isSolar = this.$store.getters[`map/building_${this.$route.params.id}/meterGroups`][0].type === 'Solar Panel'
-        } else {
-          isSolar = false
-        }
-
         switch (parseInt(this.$route.params.range)) {
           case 1:
             return 'hour'
           case 2:
-            if (isSolar) return 'hour'
             return 'day'
           case 3:
-            if (isSolar) return 'hour'
             return 'day'
           default:
             return 'minute'

--- a/src/store/block.module.js
+++ b/src/store/block.module.js
@@ -220,11 +220,9 @@ const actions = {
         let moduleSpace = store.getters.path + '/' + chartSpace
         this.registerModule(moduleSpace.split('/'), Chart)
         let utilityType = ''
-        let blockClassInt = ''
         if (this.getters[payload.group.path + '/meters'].length > 0) {
           await this.getters[payload.group.path + '/meters'][0].promise
           utilityType = this.getters[this.getters[payload.group.path + '/meters'][0].path + '/type']
-          blockClassInt = this.getters[this.getters[payload.group.path + '/meters'][0].path + '/classInt']
         }
         // this defines the "default chart", "Total Electricity"
         store.commit(chartSpace + '/name', 'Total ' + utilityType)
@@ -255,19 +253,7 @@ const actions = {
         // default chart settings
         store.commit('dateInterval', 1)
         store.commit('graphType', 1)
-
-        // change default interval for solar panels
-        // Note: this parameter is often modified elsewhere in the dashboard
-        // E.g. Building list component changes it via a Vue router parameter
-        if (utilityType === 'Solar Panel' || blockClassInt === 9990002) {
-          // Solar panel webscraper uploads time_seconds in UTC
-          // so we're gonna need to add the offset for the correct time
-          // in pacific standard time.
-          store.commit('timeZoneOffset', 420 * 60)
-          store.commit('intervalUnit', 'hour')
-        } else {
-          store.commit('intervalUnit', 'day')
-        }
+        store.commit('intervalUnit', 'day')
 
         let currentEpoch = new Date().getTime()
         currentEpoch = currentEpoch - (currentEpoch % (900 * 1000))


### PR DESCRIPTION
## Issue
- https://github.com/OSU-Sustainability-Office/energy-dashboard/issues/305
- Forgot to make an issue for the week label capitalization but should be self explanatory (`1 week` > `1 Week`)

## Testing (timeframe override)
- Solar building (not tesla): http://localhost:8080/#/building/42/2
- Solar building (tesla): http://localhost:8080/#/building/35/2

## Screenshot
![image](https://github.com/OSU-Sustainability-Office/energy-dashboard/assets/82061589/9183be08-f645-46e8-977d-da0b99088ee4)
