### PR TITLE
Temporary LINC meter fix (front-end)

### DIFF
--- a/.github/workflows/gh-deploy.yml
+++ b/.github/workflows/gh-deploy.yml
@@ -14,9 +14,9 @@ jobs:
       - name: unit tests
         working-directory: backend
         run: |
-          docker-compose build
-          docker-compose run --rm test
-          docker-compose down
+          docker compose build
+          docker compose run --rm test
+          docker compose down
 
   build-deploy-gh-pages:
     name: Build / Deploy to gh-pages

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -14,9 +14,9 @@ jobs:
       - name: unit tests
         working-directory: backend
         run: |
-          docker-compose build
-          docker-compose run --rm test
-          docker-compose down
+          docker compose build
+          docker compose run --rm test
+          docker compose down
           
   build-deploy-s3:
     name: Build / Deploy to S3 Test Build

--- a/src/store/chart.module.js
+++ b/src/store/chart.module.js
@@ -75,6 +75,15 @@ const actions = {
 
     await chartModifier.postGetData(chartData, reqPayload, this, store)
 
+    // fix LINC meter being off by factor of 10
+    // TODO: look into fixing data as it goes into the database instead of here
+    // See this issue for more info: https://github.com/OSU-Sustainability-Office/energy-dashboard/issues/341
+    if (store.getters.meterGroupPath.split('_')[2] === '199' && store.getters.point === 'accumulated_real') {
+      chartData.data.map(d => {
+        d.y = d.y * 10
+      })
+    }
+
     // fix PacificPower meters chart being filled by the energy_change chart modifier
     if (isPacificPowerMeter) {
       chartData.fill = false


### PR DESCRIPTION
The LINC meter with ID 105 (previously labeled MDS but is now the main LINC meter) was off by a factor of 10. 

Database/Back-end Fix
---
I first tried fixing the data in the DB directing via [this branch](https://github.com/OSU-Sustainability-Office/energy-dashboard/tree/linc-mds-multiplier). Even though all of the data was correctly multiplied by 10 here and in the database from 1/1/2024 to now to test it, something was off with the math on the front-end, causing some stretches of data to look similar to before and some being correct, with huge jumps in between. I'm going to leave the issue open for now and look into this more at a later time.

Front-end Fix
---
This will catch the meter after the accumulation math and check if it's the main LINC meter (meter_group_id 199) and accumulated real, and multiply it all by 10. This should be removed after we work out the issues described above.