### PR TITLE
Solar Meter Upload Update

### DIFF
--- a/backend/app/meter.js
+++ b/backend/app/meter.js
@@ -28,14 +28,14 @@ exports.all = async (event, context) => {
 }
 
 // Check integral parameters.
-function parseParameters({ id, startDate, endDate }) {
+function parseParameters ({ id, startDate, endDate }) {
   return {
     id: parseInt(id, 10),
     startDate: parseInt(startDate, 10),
     endDate: parseInt(endDate, 10)
   }
 }
-function verifyParameters({ id, startDate, endDate }) {
+function verifyParameters ({ id, startDate, endDate }) {
   return ![id, startDate, endDate].some(isNaN)
 }
 // Get data for multiple meters => {id -> [{}...], ...}
@@ -98,9 +98,8 @@ exports.upload = async (event, context) => {
   }
 
   await DB.connect()
-  let row = []
   try {
-    row = await DB.query(`SHOW TABLES LIKE ?;`, [meter_id])
+    await DB.query(`SHOW TABLES LIKE ?;`, [meter_id]) // Check if table exists
   } catch {
     response.statusCode = 400
     return response


### PR DESCRIPTION
This changes the `totalYieldYesterday` value for Solar Meters to `totalYield` since we are going to start checking the past few days for missed uploads. It also checks for duplicate data before uploading to the database. To test it, run the [Ennex branch here](https://github.com/OSU-Sustainability-Office/automated-jobs/pull/84) with the `--local-api` flag after starting up the backend locally. The database should be up to date to today, so feel free to delete one row from the `Solar_Meters` table to test that it will upload non-duplicate data as well. 