### PR TITLE
Add Missing Tesla Solar Meter

### DIFF
--- a/src/components/charts/chartController.vue
+++ b/src/components/charts/chartController.vue
@@ -63,6 +63,14 @@
       width="1000"
       title="NWREC Data Solar Array"
     ></iframe>
+    <iframe
+      v-if="this.path === 'map/building_85/block_264'"
+      :class="iframeClass"
+      src="https://mysolarcity.com/share/BB1ABBE8-1FB9-4C17-BB0A-A1DE9339DB1C#/monitoring/historical/month"
+      height="600"
+      width="1000"
+      title="Aquatic Animal Health Lab Solar Array"
+    ></iframe>
     <el-col :span="24" class="NoData" :style="`height:${height}px;line-height:${height}px;`" v-if="graphType == 100"
       >Data Unavailable</el-col
     >

--- a/src/components/view/card.vue
+++ b/src/components/view/card.vue
@@ -10,7 +10,8 @@
       this.path === 'map/building_35/block_175' ||
       this.path === 'map/building_36/block_176' ||
       this.path === 'map/building_37/block_177' ||
-      this.path === 'map/building_38/block_178'
+      this.path === 'map/building_38/block_178' ||
+      this.path === 'map/building_85/block_264'
     "
   >
     <el-row :span="24" class="title" ref="title">
@@ -55,6 +56,13 @@
     <p v-if="this.path === 'map/building_38/block_178'">
       <a
         href="https://mysolarcity.com/Share/47cf089a-5b93-4200-8566-e030cb4f8574#/monitoring/historical/month"
+        target="_blank"
+        >Data Provided by Tesla</a
+      >
+    </p>
+    <p v-if="this.path === 'map/building_85/block_264'">
+      <a
+        href="https://mysolarcity.com/share/BB1ABBE8-1FB9-4C17-BB0A-A1DE9339DB1C#/monitoring/historical/month"
         target="_blank"
         >Data Provided by Tesla</a
       >


### PR DESCRIPTION
One of our five [Tesla Solar Meter Buildings](https://sustainability.oregonstate.edu/ground-mounted-photovoltaic-arrays) was missing from the dashboard. I've added it to the database (currently hidden from production view) and updated the hard-coded values required to show it on the dashboard. For future reference, these are the `INSERT` statements for adding a new Tesla Solar Meter:

Buildings:
*  start out as hidden (value of 1), then change to 0 when finished testing so it shows up in production
```
INSERT INTO buildings (map_id, image, `group`, `name`, hidden)
VALUES (1130766362, "aquatic_animal_health_lab.jpg", "Admin & Operations", "Aquatic Animal Health Lab", 1);
```

Meters: 
* I don't think the name matters for these meters anymore, the existing Tesla meters have what look like auto-generated names (M0093...) that may have been from when the data was scraped instead of embedded.
```
INSERT INTO meters (`name`, `type`, class)
VALUES ("AAHL Solar Panels", "E", 9990001);
```

Meter Groups:
```
INSERT INTO meter_groups (`name`, `user_id`, is_building, affiliation, building_id_2, `default`)
VALUES ("Aquatic Animal Health Lab Solar Array", 1, 1, "Solar", 85, 1);
```

Meter Group Relation:
```
INSERT INTO meter_group_relation (meter_id, group_id, operation)
VALUES (184, 264, 0);
```

Result
---
![image](https://github.com/user-attachments/assets/2e36c8b1-f2b3-4d0c-bcef-8cb875022601)
![image](https://github.com/user-attachments/assets/2ad15403-310b-42fd-9dff-65035799e78b)
![image](https://github.com/user-attachments/assets/086cbd8f-169a-46ea-b1d4-879d0d287668)
![image](https://github.com/user-attachments/assets/a154f16c-3cfd-458f-99e5-ede55289d822)

- [ ] Unhide building after PR is approved and merged