### PR TITLE
Avoid getData() API calls for tesla meters

### DIFF
--- a/backend/dependencies/nodejs/models/meter.js
+++ b/backend/dependencies/nodejs/models/meter.js
@@ -141,19 +141,7 @@ class Meter {
       if (String(meterClass).startsWith('999')) {
         // get table name from meter table
         let [{ name: meter_table_name }] = await DB.query('SELECT `name` FROM meters WHERE id = ?', [this.id])
-        const teslaMeterIds = ['83', '84', '85', '86', '118']
-        if (String(meterClass) === '9990001' && teslaMeterIds.includes(String(this.id))) {
-          return DB.query(
-            'SELECT ' +
-              point +
-              ", time_seconds AS time, '" +
-              this.id +
-              "' as id FROM " +
-              meter_table_name +
-              ' WHERE time_seconds >= ? AND time_seconds <= ?',
-            [startTime, endTime]
-          )
-        } else if (meter_table_name === 'Solar_Meters') {
+        if (String(meterClass) === '9990001' && meter_table_name === 'Solar_Meters') {
           return DB.query(
             'SELECT ' +
               point +
@@ -164,10 +152,8 @@ class Meter {
               ' WHERE time_seconds >= ? AND time_seconds <= ? AND MeterID = ? order by time_seconds DESC',
             [startTime, endTime, this.id]
           )
-        }
-
+        } else {
         // pacific power meters, may need to change to else-if if there are going to be more custom classes starting with 999
-        else {
           let [{ pacific_power_id: pp_id }] = await DB.query('SELECT pacific_power_id FROM meters WHERE id = ?', [
             this.id
           ])

--- a/src/store/block.module.js
+++ b/src/store/block.module.js
@@ -302,6 +302,8 @@ const actions = {
           }
           chartDataPromises.push(this.dispatch(chart.path + '/getData', reqPayload))
         }
+      } else if (store.getters.isTeslaMeter(this.getters[chart.meterGroupPath + '/meters'][0])) {
+        // Skip Tesla meters since there is no data to get
       } else {
         chartDataPromises.push(this.dispatch(chart.path + '/getData', reqPayload))
       }
@@ -476,6 +478,14 @@ const getters = {
 
   chart: state => id => {
     return state[`chart_${id}`]
+  },
+
+  isTeslaMeter: state => meter => {
+    const teslaMeterIds = ['83', '84', '85', '86', '118', '184']
+    if (teslaMeterIds.includes(meter.id)) {
+      return true
+    }
+    return false
   }
 }
 /*


### PR DESCRIPTION
Previously, Tesla meter data was stored and managed by the energy dashboard. However, we have since switched to using an iFrame to display Tesla data directly from the source. Unfortunately, the legacy logic for retrieving Tesla meter data from our database was never removed. This outdated API call is now generating errors, which in turn trigger false alarms in AWS Cloudwatch. By removing or bypassing this API call for Tesla data, I'm hoping it gets rid of the false alarms.
