### PR TITLE
Add npm/docker version updates to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,19 @@
 version: 2
 updates:
+  # Enable version updates for Github Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    schedule:
+      interval: "weekly"
+
+  #  Enable version updates for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  #  Enable version updates for Docker
+  - package-ecosystem: "docker"
+    directory: "/backend"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
With the Energy Dashboard relying on a high amount of dependencies that are ever-changing, I've updated the dependabot to check for updates within the Docker (Dockerfile) + NPM (package.json) environments.