### PR TITLE
Fix campaign bugs

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VITE_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
+VITE_ROOT_API=http://localhost:3000
 VITE_HOST_ADDRESS=http://localhost:8080

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VITE_ROOT_API=http://localhost:3000
+VITE_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
 VITE_HOST_ADDRESS=http://localhost:8080

--- a/src/components/campaigns/campaign_building_list.vue
+++ b/src/components/campaigns/campaign_building_list.vue
@@ -69,41 +69,18 @@ export default {
   computed: {
     blocks: {
       get () {
-        let blocks = this.$store.getters[this.path + '/blocks']
-        if (!blocks) {
-          return []
-        }
-        blocks.sort((a, b) => {
-          try {
-            const aPercentage = this.accumulatedPercentage(a.path)
-            const bPercentage = this.accumulatedPercentage(b.path)
-            if (aPercentage > bPercentage) {
-              return 1
-            } else {
-              return -1
-            }
-          } catch (error) {
-            return 1
-          }
-        })
+        // Create a copy of the blocks array to trigger reactivity
+        const blockCopy = this.$store.getters[this.path + '/blocks'] || []
 
-        // Sort blocks with NaN percentages (no data) to the bottom
-        blocks.sort((a, b) => {
-          try {
-            const aPercentage = this.accumulatedPercentage(a.path)
-            const bPercentage = this.accumulatedPercentage(b.path)
-            if (isNaN(aPercentage) && !isNaN(bPercentage)) {
-              return 1
-            } else if (isNaN(aPercentage) || isNaN(bPercentage)) {
-              return -1
-            } else {
-              return 1
-            }
-          } catch (error) {
-            return 1
-          }
-        })
-        return blocks
+        // Sort the blocks based on accumulated percentage
+        return [...blockCopy]
+          .sort((a, b) => {
+            const pA = this.accumulatedPercentage(a.path)
+            const pB = this.accumulatedPercentage(b.path)
+            if (isNaN(pA) && !isNaN(pB)) return 1
+            if (!isNaN(pA) && isNaN(pB)) return -1
+            return pA - pB
+          })
       }
     }
   },

--- a/src/components/campaigns/main_campaign_view.vue
+++ b/src/components/campaigns/main_campaign_view.vue
@@ -32,6 +32,7 @@
                   :days="days"
                   :campaignDateStart="campaignStart"
                   :campaignDateEnd="campaignEnd"
+                  :forceUpdate="true"
                 />
               </el-col>
             </el-row>

--- a/src/components/map/sideView.vue
+++ b/src/components/map/sideView.vue
@@ -20,7 +20,7 @@
       <el-main class="graphcontrol">
         <el-col :span="24">
           <el-col :span="24" class="buttonContainer">
-            <switchButtons :blocks="buildingBlocks" ref="switchbutton" />
+            <switchButtons :blocks="buildingBlocks" :forceUpdate="false" ref="switchbutton" />
           </el-col>
           <el-row class="graphslide">
             <i class="left fas fa-angle-left" @click="prev()" ref="prevArrow"></i>

--- a/src/components/map/time_switch_buttons_big.vue
+++ b/src/components/map/time_switch_buttons_big.vue
@@ -20,7 +20,7 @@
 </template>
 <script>
 export default {
-  props: ['height', 'campaign', 'days', 'blocks', 'campaignDateEnd', 'campaignDateStart'],
+  props: ['height', 'campaign', 'days', 'blocks', 'campaignDateEnd', 'campaignDateStart', 'forceUpdate'],
   data () {
     return {
       currentRange: -1
@@ -99,6 +99,9 @@ export default {
           this.$store.commit(block.path + '/intervalUnit', intervalUnit)
           this.$store.commit(block.path + '/dateStart', dateStart)
           this.$store.commit(block.path + '/dateEnd', dateEnd)
+          if (this.forceUpdate) { // used to trigger a refresh for the campaign leaderboard
+            this.$store.dispatch(block.path + '/getData')
+          }
         }
       }
     }

--- a/src/store/campaigns.module.js
+++ b/src/store/campaigns.module.js
@@ -37,11 +37,11 @@ const actions = {
             store.commit(campaign + '/id', c.id)
             store.commit(
               campaign + '/dateStart',
-              new Date(c.dateStart).getTime() - new Date().getTimezoneOffset() * 60 * 1000
+              new Date(c.dateStart).getTime()
             )
             store.commit(
               campaign + '/dateEnd',
-              new Date(c.dateEnd).getTime() - new Date().getTimezoneOffset() * 60 * 1000
+              new Date(c.dateEnd).getTime()
             )
             store.commit(campaign + '/compareStart', new Date(c.compareStart).getTime())
             store.commit(campaign + '/compareEnd', new Date(c.compareEnd).getTime())

--- a/src/store/chart_modifiers/index.js
+++ b/src/store/chart_modifiers/index.js
@@ -10,6 +10,7 @@ import LineBaselineAvg from './line_bar/avg_accumulated_real.js'
 import LineDefault from './line_bar/default.js'
 import LineTotalBaseline from './line_bar/baseline_total.js'
 import LineTotalPercModifier from './line_bar/baseline_perc_total.js'
+import LinePeriodicReal from './line_bar/periodic_real.js'
 
 export default function (graphType, point) {
   if (graphType === 1 || graphType === 2) {
@@ -29,6 +30,10 @@ export default function (graphType, point) {
         return new LineTotalBaseline()
       case 'baseline_perc_total':
         return new LineTotalPercModifier()
+      case 'periodic_real_in':
+        return new LinePeriodicReal()
+      case 'periodic_real_out':
+        return new LinePeriodicReal()
       default:
         return new LineDefault()
     }

--- a/src/store/chart_modifiers/line_bar/avg_accumulated_real.js
+++ b/src/store/chart_modifiers/line_bar/avg_accumulated_real.js
@@ -105,9 +105,9 @@ export default class LineAvgModifier {
     }
 
     // Compute the average for each bin
-    for (let i = this.dateStart; i < this.dateEnd; i += delta) {
+    for (let i = this.dateStart; i + delta <= this.dateEnd; i += delta) {
       try {
-        const timestamp = new Date((delta + i) * 1000)
+        const timestamp = new Date((i + delta) * 1000)
         const timeBinIndex = Math.floor(((i + delta) % SECONDS_PER_DAY) / delta)
         let baselinePoint = avgBins[timestamp.getDay()][timeBinIndex]
         returnData.push({ x: timestamp, y: baselinePoint })

--- a/src/store/chart_modifiers/line_bar/baseline_perc_total.js
+++ b/src/store/chart_modifiers/line_bar/baseline_perc_total.js
@@ -41,7 +41,7 @@ export default class LineTotalPercModifier {
 
     for (const currentTimestamp of rawData.keys()) {
       // Shift timestamp backward by the comparison period to align with the baseline range
-      const baselineTimestamp = currentTimestamp - (compareEnd - compareStart + 86400)
+      const baselineTimestamp = currentTimestamp - (compareEnd - compareStart)
       const baselineValue = baselineData.get(baselineTimestamp)
 
       if (!isNaN(baselineValue)) {

--- a/src/store/chart_modifiers/line_bar/baseline_total.js
+++ b/src/store/chart_modifiers/line_bar/baseline_total.js
@@ -53,7 +53,7 @@ export default class LineTotalBaseline {
 
     for (const timestamp of rawData.keys()) {
       // Shift timestamp backward by the comparison period to align with the baseline range
-      const baselineTimestamp = timestamp - (compareEnd - compareStart + 86400)
+      const baselineTimestamp = timestamp - (compareEnd - compareStart)
       if (isNaN(baselineData.get(baselineTimestamp))) {
         continue
       }


### PR DESCRIPTION
# Fixes #
- Aquasuite data showing as middle of the data instead of midnight. Fixed by removing offset when loading in campaign start and end dates. Works for users in PST time zone, but needs more testing to see if it'll work elsewhere.
- Leaderboard refreshing is completely fixed by reverting the forceKey removal and modifying block logic to trigger a refresh
- Aquasuite meters showing future data was fixed by adding more robust conditionals
- PPM had unrelated campaign bug that was fixed

# TODO #
- Ensure campaigns work for all time zones
- Remaining bug: PPMs show data for April 27th despite the campaign starting on the 28th. I did some testing by removing the current data and the issue persists. There's an underlying assumption that all data is in 15 min intervals due to Aquasuite data so I believe that there could be some baked-in rounding somewhere in the code which is causing weird behavior. Nevertheless, the periodic_real logic has to be fixed as well because it misbehaves when the time is set to midnight PST (such as this case). 