### PR TITLE
Fix periodic real data

### DIFF
--- a/src/store/block_modifiers/campaign_linebar.mod.js
+++ b/src/store/block_modifiers/campaign_linebar.mod.js
@@ -86,8 +86,14 @@ export default class CampaignLineBarModifier {
     const threshold = 7.5
 
     for (let i in current) {
-      // Calculate percentage difference from baseline
-      const percentage = (current[i].y / baseline[i].y) * 100 - 100
+      let percentage = 0
+      try {
+        // Calculate percentage difference from baseline
+        percentage = (current[i].y / baseline[i].y) * 100 - 100
+      } catch (e) {
+        console.error('Error calculating percentage difference:', e)
+        continue
+      }
       this.data.accumulatedPercentage += percentage // update accumulated percentage
 
       // Compute blend factor (0 to 1)

--- a/src/store/chart.module.js
+++ b/src/store/chart.module.js
@@ -46,6 +46,12 @@ const actions = {
     const chartModifier = ChartModifiers(payload.graphType, point)
     await chartModifier.preGetData(reqPayload, this, store)
 
+    // TEMPORARY FIX: If the point is periodic_real_in, we need to subtract 1 from the start date, otherwise,
+    // the data will be off by one day in the campaign charts. This is because the data is inputed as 11:59 PM
+    // so it's not in the date range when the campaign start date is 12:00 AM.
+    if (reqPayload.point === 'periodic_real_in') {
+      reqPayload.dateStart = reqPayload.dateStart - 1
+    }
     let data = await this.dispatch(store.getters.meterGroupPath + '/getData', reqPayload)
 
     let colorPayload = store.getters.color

--- a/src/store/chart_modifiers/line_bar/avg_accumulated_real.js
+++ b/src/store/chart_modifiers/line_bar/avg_accumulated_real.js
@@ -3,6 +3,8 @@
   Description: Chart modifier for processing and formatting the baseline for
   accumulated data (e.g. accumulated_real) as kWh. This is displayed on each
   of the individual building campaign pages as a line chart.
+  Note: Logic is nearly identical to baseline_perc.js, but this gets
+  a kWh difference from the baseline instead of a percentage difference.
 */
 
 export default class LineAvgModifier {
@@ -104,7 +106,7 @@ export default class LineAvgModifier {
       }
     }
 
-    // Compute the average for each bin
+    // Fill the returnData array with the average values
     for (let i = this.dateStart; i + delta <= this.dateEnd; i += delta) {
       try {
         const timestamp = new Date((i + delta) * 1000)

--- a/src/store/chart_modifiers/line_bar/baseline_perc_total.js
+++ b/src/store/chart_modifiers/line_bar/baseline_perc_total.js
@@ -65,7 +65,7 @@ export default class LineTotalPercModifier {
       // Calculate the percentage difference
       const percentageDifference = ((currentValue - avg) / avg) * 100
 
-      const startOfDay = currentDate.startOf('day')
+      const startOfDay = currentDate.startOf('day').plus({ days: 1 })
       result.push({
         x: startOfDay.toJSDate(),
         y: percentageDifference

--- a/src/store/chart_modifiers/line_bar/baseline_perc_total.js
+++ b/src/store/chart_modifiers/line_bar/baseline_perc_total.js
@@ -3,8 +3,10 @@
   Description: Chart modifier for processing and formatting the baseline for
   total data (e.g. periodic_real_in) as a percentage. This is displayed
   on the main campaign page with all of the buildings as a line chart.
+  Note: Logic is nearly identical to baseline_total.js, but this gets
+  a percentage difference from the baseline instead of a kWh difference.
 */
-
+import { DateTime } from 'luxon'
 export default class LineTotalPercModifier {
   /*
     Description: Called after getData function of chart module.
@@ -35,27 +37,39 @@ export default class LineTotalPercModifier {
     Returns: Nothing (Note: chartData is passed by reference so editiing this argument will change it in the chart update sequence)
   */
   async postGetData (chartData, payload, store, module) {
+    const { baselineData } = payload
     const rawData = chartData.data
-    const { baselineData, compareStart, compareEnd } = payload
     const result = []
+    const weekdaySums = Array(7).fill(0)
+    const weekdayCounts = Array(7).fill(0)
 
-    for (const currentTimestamp of rawData.keys()) {
-      // Shift timestamp backward by the comparison period to align with the baseline range
-      const baselineTimestamp = currentTimestamp - (compareEnd - compareStart)
-      const baselineValue = baselineData.get(baselineTimestamp)
-
-      if (!isNaN(baselineValue)) {
-        // Calculate the percentage difference
-        const currentValue = rawData.get(currentTimestamp)
-        const percentageDifference = ((currentValue - baselineValue) / baselineValue) * 100
-
-        // Format the data for the chart
-        const formattedData = {
-          x: new Date(currentTimestamp * 1000),
-          y: percentageDifference
-        }
-        result.push(formattedData)
+    // Calculate sum and count for each weekday
+    for (const [timestamp, value] of baselineData.entries()) {
+      const dt = DateTime.fromSeconds(timestamp, { zone: 'America/Los_Angeles' })
+      const weekday = dt.weekday % 7  // 0 = Sunday, 6 = Saturday
+      if (!isNaN(value)) {
+        weekdaySums[weekday] += value
+        weekdayCounts[weekday] += 1
       }
+    }
+
+    // Calculate the average for each day of the week
+    for (const [currentTimestamp, currentValue] of rawData.entries()) {
+      const currentDate = DateTime.fromSeconds(currentTimestamp, { zone: 'America/Los_Angeles' })
+
+      // Get the average value for the current date's weekday
+      const weekday = currentDate.weekday % 7
+      const count = weekdayCounts[weekday]
+      const avg = count > 0 ? weekdaySums[weekday] / count : -1
+
+      // Calculate the percentage difference
+      const percentageDifference = ((currentValue - avg) / avg) * 100
+
+      const startOfDay = currentDate.startOf('day')
+      result.push({
+        x: startOfDay.toJSDate(),
+        y: percentageDifference
+      })
     }
 
     // Prevent scenarios where there is only one valid data point

--- a/src/store/chart_modifiers/line_bar/baseline_total.js
+++ b/src/store/chart_modifiers/line_bar/baseline_total.js
@@ -67,7 +67,7 @@ export default class LineTotalBaseline {
       const count = weekdayCounts[weekday]
       const avg = count > 0 ? weekdaySums[weekday] / count : -1
 
-      const startOfDay = currentDate.startOf('day')
+      const startOfDay = currentDate.startOf('day').plus({ days: 1 })
       result.push({
         x: startOfDay.toJSDate(),
         y: avg

--- a/src/store/chart_modifiers/line_bar/periodic_real.js
+++ b/src/store/chart_modifiers/line_bar/periodic_real.js
@@ -8,7 +8,7 @@ import { DateTime } from 'luxon'
 // periodic_real meters currently don't have data for the minute or hour,
 // so we can just default to the day interval
 function getSmallIntervalKey (currentDate) {
-  const bucketStart = currentDate.startOf('day')
+  const bucketStart = currentDate.startOf('day').plus({ days: 1 })
   return Math.floor(bucketStart.toSeconds())
 }
 
@@ -21,7 +21,7 @@ function getDayBucketKey (currentDate, startDate, dateInterval) {
 
   // Determine the index of the bucket based on the day difference and the date interval
   const bucketIndex = Math.floor(dayDifference / dateInterval)
-  const bucketStart = startDate.plus({ days: bucketIndex * dateInterval })
+  const bucketStart = startDate.plus({ days: bucketIndex * dateInterval }).plus({ days: 1 })
 
   return Math.floor(bucketStart.toSeconds())
 }

--- a/src/store/chart_modifiers/line_bar/periodic_real.js
+++ b/src/store/chart_modifiers/line_bar/periodic_real.js
@@ -5,12 +5,53 @@
 */
 import { DateTime } from 'luxon'
 
-function getTimezoneOffset (epochSeconds) {
-  // Create a DateTime object in the Pacific Time Zone
-  const dt = DateTime.fromSeconds(epochSeconds, 'America/Los_Angeles')
+// periodic_real meters currently don't have data for the minute or hour,
+// so we can just default to the day interval
+function getSmallIntervalKey (currentDate) {
+  const bucketStart = currentDate.startOf('day')
+  return Math.floor(bucketStart.toSeconds())
+}
 
-  // Multiply by 60 to convert to seconds
-  return dt.offset * 60
+// This function is used for calculating bucket keys for day and week intervals.
+// It works by rounding down the current date to the nearest interval boundary
+// relative to the provided start date.
+function getDayBucketKey (currentDate, startDate, dateInterval) {
+  // Compute the different in days between the start date and the current date in the loop
+  const dayDifference = Math.floor(currentDate.diff(startDate, 'days').days)
+
+  // Determine the index of the bucket based on the day difference and the date interval
+  const bucketIndex = Math.floor(dayDifference / dateInterval)
+  const bucketStart = startDate.plus({ days: bucketIndex * dateInterval })
+
+  return Math.floor(bucketStart.toSeconds())
+}
+
+// Monthly increments are calculated by starting from the first day of the month
+// that corresponds to the start date. Data is then accumulated until the same
+// day in the following month.
+function getMonthBucketKey (currentDate, startDate) {
+  // If current date is earlier in the month than day of the
+  // start date, then it belongs to the previous month’s bucket
+  let bucketMonth = currentDate.month
+  let bucketYear  = currentDate.year
+  if (currentDate.day < startDate.day) {
+    bucketMonth -= 1
+    if (bucketMonth === 0) {
+      bucketMonth = 12
+      bucketYear -= 1
+    }
+  }
+
+  const bucketStart = DateTime.fromObject({
+    year: bucketYear,
+    month: bucketMonth,
+    day: startDate.day,
+    hour: 0,
+    minute: 0,
+    second: 0
+  })
+
+  return Math.floor(bucketStart.toSeconds())
 }
 
 export default class LinePeriodicRealModifier {
@@ -49,55 +90,51 @@ export default class LinePeriodicRealModifier {
     Returns: Nothing (Note: chartData is passed by reference so editiing this argument will change it in the chart update sequence)
   */
   async postGetData (chartData, payload, store, module) {
-    const { dateStart, dateEnd, intervalUnit, dateInterval, timezoneOffset, point } = payload
+    const { dateStart, dateEnd, dateInterval, intervalUnit, point } = payload
+    const TIMEZONE = 'America/Los_Angeles'
     const currentData = chartData.data
     const result = []
-    const startDate = new Date(dateStart * 1000)
-    const SECONDS_PER_DAY = 86400
-    let delta = 1
-    let monthDays = 1
+    const startDate = DateTime.fromSeconds(dateStart, { zone: TIMEZONE }).startOf('day')
+    const buckets = new Map()
 
-    // Determine delta based on interval unit
-    switch (intervalUnit) {
-      case 'minute':
-        delta = 60
-        break
-      case 'hour':
-        delta = 3600
-        break
-      case 'day':
-        delta = SECONDS_PER_DAY
-        break
-      case 'month':
-        monthDays = new Date(startDate.getFullYear(), startDate.getMonth() + 1, 0).getDate()
-        delta = SECONDS_PER_DAY * monthDays
-        break
-    }
-    delta *= dateInterval
+    // Aggregate data into buckets based on the specified interval
+    for (const [epoch, val] of currentData.entries()) {
+      const currentDate = DateTime.fromSeconds(epoch, { zone: TIMEZONE })
 
-    // Add the data to result array as-is since it is already a time series
-    for (let i = dateStart; i <= dateEnd; i += delta) {
-      try {
-        // Align the timestamp with the data points in the database
-        let timestamp = i - getTimezoneOffset(i)
-
-        const curValue = currentData.get(timestamp)
-        if (isNaN(curValue)) {
-          continue
-        }
-
-        // Adjust the timestamp to account for the timezone offset if needed
-        timestamp += timezoneOffset || 0
-
-        // Format the data for the chart
-        const formattedData = {
-          x: new Date(timestamp * 1000),
-          y: Math.abs(curValue)
-        }
-        result.push(formattedData)
-      } catch (error) {
-        console.log(error)
+      // Get the bucket key based on the interval unit
+      let bucketKey
+      switch (intervalUnit) {
+        case 'minute':
+          bucketKey = getSmallIntervalKey(currentDate)
+          break
+        case 'hour':
+          bucketKey = getSmallIntervalKey(currentDate)
+          break
+        case 'day':
+          bucketKey = getDayBucketKey(currentDate, startDate, dateInterval)
+          break
+        case 'month':
+          bucketKey = getMonthBucketKey(currentDate, startDate)
+          break
+        default:
+          console.error('Invalid interval unit:', intervalUnit)
+          return
       }
+
+      // Store the aggregated data in the buckets map
+      if (bucketKey > dateEnd) continue // ignore current interval (data still being collected)
+      if (!buckets.has(bucketKey)) {
+        buckets.set(bucketKey, 0)
+      }
+      buckets.set(bucketKey, buckets.get(bucketKey) + val)
+    }
+
+    // Fill the result array with the aggregated data
+    for (const [bucketEpoch, total] of buckets.entries()) {
+      result.push({
+        x: DateTime.fromSeconds(bucketEpoch, { zone: TIMEZONE }).toJSDate(),
+        y: Math.abs(total)
+      })
     }
 
     // Fill chart for Solar Panel data
@@ -137,34 +174,6 @@ export default class LinePeriodicRealModifier {
     Returns: Nothing (Note: payload is passed by reference so editiing this argument will change it in the chart update sequence)
   */
   async preGetData (payload, store, module) {
-    const { intervalUnit, dateInterval } = payload
-    const SECONDS_PER_DAY = 86400
-    const dataDate = new Date(payload.dateStart * 1000)
-    let delta = 1
-
-    switch (intervalUnit) {
-      case 'minute':
-        delta = 60
-        break
-      case 'hour':
-        delta = 3600
-        break
-      case 'day':
-        delta = SECONDS_PER_DAY
-        break
-      case 'month':
-        let monthDays = new Date(dataDate.getFullYear(), dataDate.getMonth(), 0).getDate()
-        if (dataDate.getDate() > monthDays) monthDays = dataDate.getDate()
-        delta = SECONDS_PER_DAY * monthDays
-        break
-    }
-    delta *= dateInterval
-
-    // Adjust dateStart to align with data points in the database
-    // Round down to 23:59:59
-    const adjustedTime = payload.dateStart - delta
-    const dayRemainder = adjustedTime % 86400
-    // Subtract the remainder to get the start of the day, then add 86399 to round up to 23:59:59
-    payload.dateStart = adjustedTime - dayRemainder + 86399
+    // No preprocessing needed for periodic_real data
   }
 }

--- a/src/store/meter.module.js
+++ b/src/store/meter.module.js
@@ -49,7 +49,7 @@ const actions = {
   },
 
   async getData (store, payload) {
-    let start = payload.dateStart - 900
+    let start = payload.dateStart
     let end = payload.dateEnd
     await store.getters.promise
     return this.dispatch('dataStore/getData', {

--- a/src/store/meter_group.module.js
+++ b/src/store/meter_group.module.js
@@ -115,7 +115,7 @@ const actions = {
       for (let meter of store.getters.meters) {
         dataLayerPayload.push({
           meterId: this.getters[meter.path + '/id'],
-          start: payload.dateStart - 900,
+          start: payload.dateStart,
           end: payload.dateEnd,
           uom: payload.point,
           classInt: this.getters[meter.path + '/classInt']


### PR DESCRIPTION
# Changes # 
- Removed 15-minute offset previously subtracted from dateStart to allow PPM charts to show properly. The reason for the original adjustment is unclear, but Aquasuite data appears unaffected after removal. Could be worth looking through Git Blame.
- Implemented monthly bucketing for periodic_real data (PPM + Solar Meter). Buckets start at midnight PST for consistency across campaigns. This can easily be modified to 11:59 PM in the future if needed.
- Updated PPM baseline logic to match Aquasuite’s: it now averages daily kWh usage by day of week (e.g., all Mondays in the comparison period).

# TEMPORARY FIX # 
- PPM data is stored as 11:59 PM PST, but campaign charts start at midnight PST, causing the first day’s data to be excluded.
- As a workaround, dateStart is decremented by 1 second in the request payload to ensure inclusion.
- This is obviously not ideal and a more robust solution should be implemented  as it may lead to future inconsistencies. 
- One possible idea is to change the PPM time_seconds to midnight PST in the database.