### PR TITLE
Restrict API access for building OSM update

### DIFF
--- a/backend/dependencies/nodejs/models/building.js
+++ b/backend/dependencies/nodejs/models/building.js
@@ -96,12 +96,9 @@ class Building {
     return this
   }
 
-  static async updateGeoJSON (id, geoJSON) {
+  static async updateGeoJSON(id, geoJSON) {
     await DB.connect()
-    await DB.query('UPDATE buildings SET geojson = ? WHERE id = ?', [
-      JSON.stringify(geoJSON),
-      id
-    ])
+    await DB.query('UPDATE buildings SET geojson = ? WHERE id = ?', [JSON.stringify(geoJSON), id])
   }
 
   async delete(user) {


### PR DESCRIPTION
API requests must now have a password to update the building's OSM data.