### PR TITLE
Fixing Download Data Feature

### DIFF
--- a/src/components/building_view/modals/DownloadData.vue
+++ b/src/components/building_view/modals/DownloadData.vue
@@ -298,7 +298,7 @@ export default {
           }
         }
       }
-      let dlData = await Promise.all(promises)
+      let dlData = await Promise.all(promises.map(func => func()))
       for (let dl of dlData) {
         let organizedData = [`Time,${dl.point}`]
         for (let d of dl.data) {


### PR DESCRIPTION
# Context # 
The “Download Data” button became unresponsive, even though no recent code changes had been made. Console logs revealed an error occurring during data traversal.

# Root Cause # 
The promises array was populated with functions instead of actual promise values. As a result, Promise.all() attempted to resolve an array of functions, leading to the failure.

# Solution # 
The issue was resolved by invoking the async functions before proceeding, ensuring the data was properly formatted and handled as expected.