### PR TITLE
Remove meter table name dependency for solar meters

### DIFF
--- a/backend/dependencies/nodejs/models/meter.js
+++ b/backend/dependencies/nodejs/models/meter.js
@@ -140,7 +140,9 @@ class Meter {
             'SELECT ' +
               point +
               ', time_seconds AS time, ' +
-              "'" + this.id + "' as id " +
+              "'" +
+              this.id +
+              "' as id " +
               'FROM Solar_Meters ' +
               'WHERE time_seconds >= ? ' +
               '  AND time_seconds <= ? ' +


### PR DESCRIPTION
# Summary # 
Previously, solar meters in the MySQL meters table were required to be named “Solar_Meters”. I reworked the conditional logic to instead rely on the meter class value (9990001 for solar meters), removing that naming dependency. This allows for more descriptive and readable names in the database rather than multiple rows sharing the same “Solar_Meters” label.
