### PR TITLE
Group multiple pacific power meter ids together

### DIFF
--- a/backend/dependencies/nodejs/models/meter.js
+++ b/backend/dependencies/nodejs/models/meter.js
@@ -163,17 +163,6 @@ class Meter {
             ORDER BY data.time_seconds DESC;
           `
           return query(q, [startTime, endTime, this.id])
-
-
-
-          // // pacific power meters, may need to change to else-if if there are going to be more custom classes starting with 999
-          // let [{ pacific_power_id: pp_id }] = await query('SELECT pacific_power_id FROM meters WHERE id = ?', [this.id])
-          // return query(
-          //   'SELECT ' +
-          //     point +
-          //     ', time_seconds AS time FROM pacific_power_data WHERE time_seconds >= ? AND time_seconds <= ? AND pacific_power_meter_id = ? order by time_seconds DESC;',
-          //   [startTime, endTime, pp_id]
-          // )
         }
       }
       // Aquisuites


### PR DESCRIPTION
# Context #
The meter for Azalea House (Formerly Pacific Power ID #78444191) suddenly stopped outputting data on the Pacific Power website on August 5th, 2025. On August 7th, 2025, a new meter was detected (Pacific Power ID #74263961). After further review, it was discovered that this newfound meter ID was actually referring to the same Azalea House meter.

It turns out that Pacific Power occasionally generate a new meter ID. Thus, it is possible that one meter will be associated with multiple pacific power meter IDs. This is problematic because our database assumes a 1:1 relationship between meters and meter IDs. Therefore, there is actually a 1:M relationship between meters and meter IDs (one meter can have many meter IDs).

# Solution # 
With the addition of a dedicated foreign key mapping table, we can now query multiple Pacific Power meter IDs associated with a single meter and return their combined data over any time range.