### PR TITLE
Fix pp mass requests

### DIFF
--- a/src/store/data_layer/data_store.js
+++ b/src/store/data_layer/data_store.js
@@ -505,31 +505,31 @@ const actions = {
 
 // Merges a new interval into a list of existing intervals while maintaining sorted order
 function mergeIntervals(intervals, newInterval) {
-  const res = [];
-  const n = intervals.length;
-  let i = 0;
+  const res = []
+  const n = intervals.length
+  let i = 0
 
   // Add all intervals that end before newInterval starts
   while (i < n && intervals[i][1] < newInterval[0]) {
-    res.push(intervals[i]);
-    i++;
+    res.push(intervals[i])
+    i++
   }
 
   // Merge all overlapping intervals into newInterval
   while (i < n && intervals[i][0] <= newInterval[1]) {
-    newInterval[0] = Math.min(newInterval[0], intervals[i][0]);
-    newInterval[1] = Math.max(newInterval[1], intervals[i][1]);
-    i++;
+    newInterval[0] = Math.min(newInterval[0], intervals[i][0])
+    newInterval[1] = Math.max(newInterval[1], intervals[i][1])
+    i++
   }
-  res.push(newInterval);
-  
+  res.push(newInterval)
+
   // Add rest of intervals that start after newInterval ends
   while (i < n) {
-    res.push(intervals[i]);
-    i++;
+    res.push(intervals[i])
+    i++
   }
 
-  return res;
+  return res
 }
 
 const mutations = {


### PR DESCRIPTION
# Problem # 
Energy data is cached in the user’s browser to avoid unnecessary network requests. The cache stores meter readings locally and attempts to determine which time intervals are missing and require server fetches.

The current logic:
- Loads all cached data for a given meter ID + unit of measure.
- Filters out any cached timestamps outside the requested [start, end] range.
- Sorts the remaining timestamps in ascending order.
- Keeps: the first timestamp, the last timestamp, and any intermediate timestamps where gaps exceed 15 minutes.
- Uses these filtered timestamps to infer gaps and build a list of missing intervals to request from the server.

However, this approach has multiple flaws:
- It assumes meters produce data in fixed 15-minute intervals, which is false for certain meter groups (e.g. Pacific Power).
- It treats large missing intervals caused by expected circumstances (meter outages, upload failures, etc.) as incomplete cache, causing redundant queries for data that does not exist.

In the screenshot shown, the first interval is the only actual missing interval. The following two intervals represent real, permanent data gaps caused by meter downtime. But the client continues requesting these ranges endlessly, because the cache logic believes they were never fetched.
<img width="675" height="315" alt="image" src="https://github.com/user-attachments/assets/ec61da7a-5bfc-4d56-b6a0-f125e9d30e2f" />

# Solution # 
1) For each coverage[meter][unit of measure], store a tuple such as:
- Start: The first timestamp of the returned interval
- End: The last timestamp of the returned interval

2) Compare the requested interval to each of the cached intervals. Merge intervals where possible. Return the missing interval(s).
- Strangely, there is already a function that caches the intervals and merges them together when possible. Thus, all we have to do is add logic to check the requested interval against the cached intervals to find the missing intervals.