### PR TITLE
Bump frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "npm-run-all": "^4.1.5",
         "prettier": "^3.7.4",
         "raw-loader": "^4.0.2",
-        "sass": "^1.96.0",
+        "sass": "^1.93.2",
         "vite": "^7.2.7",
         "vite-svg-loader": "^5.1.0",
         "vue-eslint-parser": "^10.2.0"
@@ -11823,9 +11823,9 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.96.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.96.0.tgz",
-      "integrity": "sha512-8u4xqqUeugGNCYwr9ARNtQKTOj4KmYiJAVKXf2CTIivTCR51j96htbMKWDru8H5SaQWpyVgTfOF8Ylyf5pun1Q==",
+      "version": "1.93.2",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
+      "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^3.7.4",
     "raw-loader": "^4.0.2",
-    "sass": "^1.96.0",
+    "sass": "^1.93.2",
     "vite": "^7.2.7",
     "vite-svg-loader": "^5.1.0",
     "vue-eslint-parser": "^10.2.0"


### PR DESCRIPTION
Dependency Bumps
- axios: ^1.12.2 → ^1.13.2
- chart.js: ^4.5.0 → ^4.5.1
- element-plus: ^2.11.4 → ^2.12.0
- vue: ^3.5.22 → ^3.5.25
- vue-chartjs: ^5.3.2 → ^5.3.3
- vue-router: ^4.5.0 → ^4.6.4

Dev Dependency Bumps
- @vitejs/plugin-vue: ^6.0.1 → ^6.0.3
- autoprefixer: ^10.4.21 → ^10.4.22
- eslint: ^9.38.0 → ^9.39.2
- eslint-plugin-vue: ^10.5.0 → ^10.6.2
- fake-indexeddb: ^6.2.4 → ^6.2.5
- prettier: ^3.6.2 → ^3.7.4
- vite: ^7.1.10 → ^7.2.7

No breaking changes occured.