### PR TITLE
Remove sub-daily interval UI options

### DIFF
--- a/src/components/building_view/BuildingPanel.vue
+++ b/src/components/building_view/BuildingPanel.vue
@@ -122,8 +122,8 @@ export default {
     return {
       editcard: false,
       tempName: '',
-      interval: 15,
-      interval_unit: 'minute',
+      interval: 1,
+      interval_unit: 'day',
       date_start: '',
       date_end: '',
       graphtype: 1,
@@ -152,39 +152,27 @@ export default {
     },
     intunit: {
       get: function () {
-        if (this.interval === 15 && this.interval_unit === 'minute') {
-          return 1 // 15 minutes
-        } else if (this.interval === 1 && this.interval_unit === 'hour') {
-          return 2 // 1 hour
-        } else if (this.interval === 1 && this.interval_unit === 'day') {
-          return 3 // 1 day
+        if (this.interval === 1 && this.interval_unit === 'day') {
+          return 1 // 1 day
         } else if (this.interval === 7 && this.interval_unit === 'day') {
-          return 4 // 1 week
+          return 2 // 1 week
         } else if (this.interval === 1 && this.interval_unit === 'month') {
-          return 5 // 1 month
+          return 3 // 1 month
         } else {
-          return 1 // default to 15 minutes
+          return 1 // default to 1 day
         }
       },
       set: function (v) {
         switch (v) {
           case 1:
-            this.interval = 15
-            this.interval_unit = 'minute'
-            break
-          case 2:
-            this.interval = 1
-            this.interval_unit = 'hour'
-            break
-          case 3:
             this.interval = 1
             this.interval_unit = 'day'
             break
-          case 4:
+          case 2:
             this.interval = 7
             this.interval_unit = 'day'
             break
-          case 5:
+          case 3:
             this.interval = 1
             this.interval_unit = 'month'
             break

--- a/src/components/building_view/modals/DownloadData.vue
+++ b/src/components/building_view/modals/DownloadData.vue
@@ -64,11 +64,9 @@
       >
         <!-- <label class='col-4'>Interval: </label> -->
         <el-select v-model="form.intUnit" style="width: 100%">
-          <el-option :value="1" label="15 Minutes"></el-option>
-          <el-option :value="2" label="1 Hour"></el-option>
-          <el-option :value="3" label="1 Day"></el-option>
-          <el-option :value="4" label="1 Week"></el-option>
-          <el-option :value="5" label="1 Month"></el-option>
+          <el-option :value="1" label="1 Day"></el-option>
+          <el-option :value="2" label="1 Week"></el-option>
+          <el-option :value="3" label="1 Month"></el-option>
         </el-select>
       </el-form-item>
       <el-form-item
@@ -144,7 +142,7 @@ export default {
       form: {
         start: '',
         end: '',
-        intUnit: 5,
+        intUnit: 3,
         buildings: [],
         points: []
       }
@@ -328,7 +326,7 @@ export default {
       this.form.points = []
       this.form.start = ''
       this.form.end = ''
-      this.form.intUnit = 5
+      this.form.intUnit = 3
 
       const path = this.$store.getters['modalController/data'].view
       for (let block of this.$store.getters[path + '/blocks']) {
@@ -382,48 +380,37 @@ export default {
     interval: function (intUnit) {
       switch (intUnit) {
         case 1:
-          return 'minute'
+          return 'day'
         case 2:
-          return 'hour'
+          return 'day'
         case 3:
-          return 'day'
-        case 4:
-          return 'day'
-        case 5:
           return 'month'
         default:
-          return 'minute'
+          return 'day'
       }
     },
     date: function (intUnit) {
       switch (intUnit) {
         case 1:
-          return 15
-        case 2:
           return 1
+        case 2:
+          return 7
         case 3:
           return 1
-        case 4:
-          return 7
-        case 5:
-          return 1
         default:
-          return 15
+          return 1
       }
     },
 
     intUnit: function (intervalUnit, dateInterval) {
-      if (dateInterval === 15 && intervalUnit === 'minute') {
+      if (dateInterval === 1 && intervalUnit === 'day') {
         return 1
-      } else if (dateInterval === 1 && intervalUnit === 'hour') {
-        return 2
-      } else if (dateInterval === 1 && intervalUnit === 'day') {
-        return 3
       } else if (dateInterval === 7 && intervalUnit === 'day') {
-        return 4
+        return 2
       } else if (dateInterval === 1 && intervalUnit === 'month') {
-        return 5
+        return 3
       }
+      return 1
     }
   }
 }

--- a/src/components/building_view/modals/EditModal.vue
+++ b/src/components/building_view/modals/EditModal.vue
@@ -68,11 +68,9 @@
         prop="intUnit"
       >
         <el-select v-model="form.intUnit" style="width: 100%">
-          <el-option :value="1" label="15 Minutes"></el-option>
-          <el-option :value="2" label="1 Hour"></el-option>
-          <el-option :value="3" label="1 Day"></el-option>
-          <el-option :value="4" label="1 Week"></el-option>
-          <el-option :value="5" label="1 Month"></el-option>
+          <el-option :value="1" label="1 Day"></el-option>
+          <el-option :value="2" label="1 Week"></el-option>
+          <el-option :value="3" label="1 Month"></el-option>
         </el-select>
       </el-form-item>
       <!-- Meter -->
@@ -354,48 +352,37 @@ export default {
     interval: function (intUnit) {
       switch (intUnit) {
         case 1:
-          return 'minute'
+          return 'day'
         case 2:
-          return 'hour'
+          return 'day'
         case 3:
-          return 'day'
-        case 4:
-          return 'day'
-        case 5:
           return 'month'
         default:
-          return 'minute'
+          return 'day'
       }
     },
     date: function (intUnit) {
       switch (intUnit) {
         case 1:
-          return 15
-        case 2:
           return 1
+        case 2:
+          return 7
         case 3:
           return 1
-        case 4:
-          return 7
-        case 5:
-          return 1
         default:
-          return 15
+          return 1
       }
     },
 
     intUnit: function (intervalUnit, dateInterval) {
-      if (dateInterval === 15 && intervalUnit === 'minute') {
+      if (dateInterval === 1 && intervalUnit === 'day') {
         return 1
-      } else if (dateInterval === 1 && intervalUnit === 'hour') {
-        return 2
-      } else if (dateInterval === 1 && intervalUnit === 'day') {
-        return 3
       } else if (dateInterval === 7 && intervalUnit === 'day') {
-        return 4
+        return 2
       } else if (dateInterval === 1 && intervalUnit === 'month') {
-        return 5
+        return 3
       }
+      return 1
     },
 
     buttonVariant: function (index) {

--- a/src/components/ui/TimeRangeSwitcher.vue
+++ b/src/components/ui/TimeRangeSwitcher.vue
@@ -6,11 +6,11 @@
 <template>
   <el-row class="buttons">
     <el-col :span="8" class="rangeButtonParent" v-bind:class="{ active: currentRange == 0 }">
-      <el-button class="rangeButton" @click="currentRange = 0">{{ campaign ? 'Past 6 Hours' : 'Week' }}</el-button>
+      <el-button class="rangeButton" @click="currentRange = 0">{{ campaign ? 'Past 7 Days' : 'Week' }}</el-button>
     </el-col>
-    <el-col :span="8" class="rangeButtonParent" v-bind:class="{ active: currentRange == 1 || currentRange == 3 }">
+    <el-col :span="8" class="rangeButtonParent" v-bind:class="{ active: currentRange == 1 }">
       <!--Change default interval for Solar Panels-->
-      <el-button class="rangeButton" @click="currentRange = 1">{{ campaign ? 'Past Day' : '60 Days' }}</el-button>
+      <el-button class="rangeButton" @click="currentRange = 1">{{ campaign ? 'Past 30 Days' : '60 Days' }}</el-button>
     </el-col>
     <el-col :span="8" class="rangeButtonParent" v-bind:class="{ active: currentRange == 2 }">
       <el-button class="rangeButton" @click="currentRange = 2">{{
@@ -22,20 +22,17 @@
 <script>
 // constants
 const DAY_IN_MS = 24 * 60 * 60 * 1000 // 1 day in ms
-const HOUR_IN_MS = 60 * 60 * 1000 // 1 hour in ms
-const FIFTEEN_MIN_IN_MS = 15 * 60 * 1000 // 15 minutes in ms
-const floorTo = (t, ms) => t - (t % ms)
 
 // per-mode presets for each range button
 const TIME_RANGE_PRESETS = {
   noCampaign: {
-    0: { unit: 'hour', interval: 6, startMs: 7 * DAY_IN_MS }, // past week
+    0: { unit: 'day', interval: 1, startMs: 7 * DAY_IN_MS }, // past week
     1: { unit: 'day', interval: 1, startMs: 60 * DAY_IN_MS }, // past 60 days
     2: { unit: 'day', interval: 15, startMs: 365 * DAY_IN_MS } // past year
   },
   campaign: {
-    0: { unit: 'minute', interval: 15, startMs: 6 * HOUR_IN_MS }, // past 6 hours
-    1: { unit: 'hour', interval: 2, startMs: DAY_IN_MS }, // past day
+    0: { unit: 'day', interval: 1, startMs: 7 * DAY_IN_MS }, // past 7 days
+    1: { unit: 'day', interval: 1, startMs: 30 * DAY_IN_MS }, // past 30 days
     2: { unit: 'day', interval: 1, startMs: null } // special case: full campaign date range
   }
 }
@@ -67,7 +64,7 @@ export default {
         const mode = this.campaign ? 'campaign' : 'noCampaign'
         const preset = TIME_RANGE_PRESETS[mode][value]
 
-        const dateEnd = this.campaign ? this.campaignDateEnd : floorTo(Date.now(), FIFTEEN_MIN_IN_MS)
+        const dateEnd = this.campaign ? this.campaignDateEnd : Date.now()
         const intervalUnit = preset.unit
         const dateInterval = preset.interval
         const dateStart =


### PR DESCRIPTION
Fixes #350 

Note: I  went with the most nuclear approach by removing all options for 15 min and 1 hour from all the modals and frontend interval selectors. These could be reverted after I check with Brandon Trelstad and the office on if he actually finds himself using the 15 min and 1 hour usage for non Pacific Power buildings.

<img width="3835" height="2107" alt="Screenshot_2026-03-11_06-25-20" src="https://github.com/user-attachments/assets/5eb1ceef-b40a-4055-b4cf-8f2807b35037" />
<img width="3835" height="2107" alt="Screenshot_2026-03-11_05-36-08" src="https://github.com/user-attachments/assets/d00aac2d-4c5d-4ddd-9e2d-41f32a2239ed" />

Considering how most of the buildings showed broken graphs when 1 hour or 15 mins were selected and how Samantha noted that pacific power only records meter reads once a day, I went with this approach for now.