### PR TITLE
Fix map modal and sidebar overflowing past map at small screen sizes

### DIFF
--- a/src/components/map/BuildingModal.vue
+++ b/src/components/map/BuildingModal.vue
@@ -196,7 +196,8 @@ export default {
 .main {
   padding: 0;
   border-radius: 5px;
-  overflow: hidden;
+  height: 100%;
+  overflow-y: auto;
   background-color: rgb(26, 26, 26);
   box-shadow: -1px 1px 6px rgba(0, 0, 0, 0.6);
 }

--- a/src/components/map/Map.vue
+++ b/src/components/map/Map.vue
@@ -668,7 +668,8 @@ $sideMenu-width: 250px;
   padding: 0;
   position: absolute;
   width: 100%;
-  height: 100%;
+  height: calc(100vh - #{$nav-height});
+  overflow: hidden;
 }
 
 .el-menu-item {
@@ -684,6 +685,8 @@ $sideMenu-width: 250px;
   width: $sideMenu-width - 10px;
   padding-top: 0.5em;
   top: 175px;
+  max-height: calc(100vh - #{$nav-height} - 175px);
+  overflow-y: auto;
 }
 
 :deep(.el-menu-item-group__title) {


### PR DESCRIPTION
Fixes Issue #534 

Summary
- At smaller viewport heights, the building info modal and left sidebar legend were extending past the map boundary into white space below
- The modal content (graph, Compare/View Full Graph buttons) was also being clipped with no way to scroll to it

Root Cause
The map stage used height: 100%, but its parent (.main in App.vue) only sets min-height, breaking the percentage height chain. This caused the modal and sidebar to position themselves relative to an unbounded container with no overflow clipping.

Changes
- Map.vue — Changed .stage to height: calc(100vh - $nav-height) so the map is always bounded to the viewport, and added overflow: hidden to clip children at the map boundary
- Map.vue — Added max-height and overflow-y: auto to .sideMenu so the sidebar scrolls instead of growing past the map
- BuildingModal.vue — Added height: 100% and overflow-y: auto to .main so the modal content is scrollable when the viewport is too short to display everything at once

Test Plan
- [ ] Open the map page and click a building to open the modal
- [ ] Resize the browser to a short viewport height (~500px)
- [ ] Confirm the modal no longer extends into white space below the map
- [ ] Confirm you can scroll within the modal to reach the graph and Compare/View Full Graph buttons
- [ ] Confirm the sidebar scrolls if the legend items exceed the available height
- [ ] Confirm other pages (Buildings, Campaigns, FAQ, Contact) are unaffected