### PR TITLE
Lower bound date

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,2 @@
-VITE_ROOT_API=http://localhost:3000
+VITE_ROOT_API=https://api.sustainability.oregonstate.edu/v2/energy
 VITE_HOST_ADDRESS=http://localhost:8080

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ packaged.yaml
 
 # sqlite testing database
 *.db
+
+# Claude Code
+CLAUDE.md

--- a/backend/wait-for-it.sh
+++ b/backend/wait-for-it.sh
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env bash
+#!/usr/bin/env bash
 # Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}

--- a/backend/wait-for-it.sh
+++ b/backend/wait-for-it.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+﻿#!/usr/bin/env bash
 # Use this script to test if a given TCP host/port are available
 
 WAITFORIT_cmdname=${0##*/}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -4,5 +4,6 @@ export default {
   trailingComma: 'none',
   arrowParens: 'avoid', // parentheses around arrow function parameters only when necessary
   tabWidth: 2, // matches ESLint's indent rule
-  semi: false
+  semi: false,
+  endOfLine: 'lf'
 }

--- a/src/components/charts/ChartController.vue
+++ b/src/components/charts/ChartController.vue
@@ -20,72 +20,72 @@
       "
       :style="`height: ${height}px; border-radius: 5px; overflow: hidden;`"
     >
-    <Linechart
-      v-if="graphType === 1 && chartData && this.path !== 'map/building_35/block_175'"
-      ref="Linechart"
-      :key="chartRenderKey"
-      :chartData="chartData"
-      :style="styleC"
-      :height="height"
-      :invertColors="invertColors"
-      :isMultipleTimePeriods="multipleTimePeriods(chartData.datasets)"
-      :buildXaxisTick="buildXaxisTick"
-      :buildLabel="buildLabel"
-      :intervalUnit="$store.getters[path + '/intervalUnit']"
-    />
-    <Barchart
-      v-if="graphType === 2 && chartData"
-      ref="Barchart"
-      :chartData="chartData"
-      :style="styleC"
-      :height="height"
-      :invertColors="invertColors"
-      :buildLabel="buildLabel"
-      :intervalUnit="$store.getters[path + '/intervalUnit']"
-    />
-    <iframe
-      v-if="this.path === 'map/building_35/block_175'"
-      :class="iframeClass"
-      src="https://mysolarcity.com/Share/007c9349-72ba-450c-aa1f-4e5a77b68f79#/monitoring/historical/month"
-      height="600"
-      width="1000"
-      title="35th Street Solar Array"
-    ></iframe>
-    <iframe
-      v-if="this.path === 'map/building_36/block_176'"
-      :class="iframeClass"
-      src="https://mysolarcity.com/share/9D5EB0D2-E376-44A1-9B8C-8DFCDD7507A5#/monitoring/historical/month"
-      height="600"
-      width="1000"
-      title="53rd Street Solar Array"
-    ></iframe>
-    <iframe
-      v-if="this.path === 'map/building_37/block_177'"
-      :class="iframeClass"
-      src="https://mysolarcity.com/Share/38954c21-8669-47b6-8376-835cc24f908c#/monitoring/historical/month"
-      height="600"
-      width="1000"
-      title="Hermiston Solar Array"
-    ></iframe>
-    <iframe
-      v-if="this.path === 'map/building_38/block_178'"
-      :class="iframeClass"
-      src="https://mysolarcity.com/Share/47cf089a-5b93-4200-8566-e030cb4f8574#/monitoring/historical/month"
-      height="600"
-      width="1000"
-      title="NWREC Data Solar Array"
-    ></iframe>
-    <iframe
-      v-if="this.path === 'map/building_85/block_264'"
-      :class="iframeClass"
-      src="https://mysolarcity.com/share/BB1ABBE8-1FB9-4C17-BB0A-A1DE9339DB1C#/monitoring/historical/month"
-      height="600"
-      width="1000"
-      title="Aquatic Animal Health Lab Solar Array"
-    ></iframe>
-    <el-col :span="24" class="NoData" :style="`height:${height}px;line-height:${height}px;`" v-if="graphType == 100"
-      >Data Unavailable</el-col
-    >
+      <Linechart
+        v-if="graphType === 1 && chartData && this.path !== 'map/building_35/block_175'"
+        ref="Linechart"
+        :key="chartRenderKey"
+        :chartData="chartData"
+        :style="styleC"
+        :height="height"
+        :invertColors="invertColors"
+        :isMultipleTimePeriods="multipleTimePeriods(chartData.datasets)"
+        :buildXaxisTick="buildXaxisTick"
+        :buildLabel="buildLabel"
+        :intervalUnit="$store.getters[path + '/intervalUnit']"
+      />
+      <Barchart
+        v-if="graphType === 2 && chartData"
+        ref="Barchart"
+        :chartData="chartData"
+        :style="styleC"
+        :height="height"
+        :invertColors="invertColors"
+        :buildLabel="buildLabel"
+        :intervalUnit="$store.getters[path + '/intervalUnit']"
+      />
+      <iframe
+        v-if="this.path === 'map/building_35/block_175'"
+        :class="iframeClass"
+        src="https://mysolarcity.com/Share/007c9349-72ba-450c-aa1f-4e5a77b68f79#/monitoring/historical/month"
+        height="600"
+        width="1000"
+        title="35th Street Solar Array"
+      ></iframe>
+      <iframe
+        v-if="this.path === 'map/building_36/block_176'"
+        :class="iframeClass"
+        src="https://mysolarcity.com/share/9D5EB0D2-E376-44A1-9B8C-8DFCDD7507A5#/monitoring/historical/month"
+        height="600"
+        width="1000"
+        title="53rd Street Solar Array"
+      ></iframe>
+      <iframe
+        v-if="this.path === 'map/building_37/block_177'"
+        :class="iframeClass"
+        src="https://mysolarcity.com/Share/38954c21-8669-47b6-8376-835cc24f908c#/monitoring/historical/month"
+        height="600"
+        width="1000"
+        title="Hermiston Solar Array"
+      ></iframe>
+      <iframe
+        v-if="this.path === 'map/building_38/block_178'"
+        :class="iframeClass"
+        src="https://mysolarcity.com/Share/47cf089a-5b93-4200-8566-e030cb4f8574#/monitoring/historical/month"
+        height="600"
+        width="1000"
+        title="NWREC Data Solar Array"
+      ></iframe>
+      <iframe
+        v-if="this.path === 'map/building_85/block_264'"
+        :class="iframeClass"
+        src="https://mysolarcity.com/share/BB1ABBE8-1FB9-4C17-BB0A-A1DE9339DB1C#/monitoring/historical/month"
+        height="600"
+        width="1000"
+        title="Aquatic Animal Health Lab Solar Array"
+      ></iframe>
+      <el-col :span="24" class="NoData" :style="`height:${height}px;line-height:${height}px;`" v-if="graphType == 100"
+        >Data Unavailable</el-col
+      >
     </div>
   </div>
 </template>

--- a/src/components/charts/ChartController.vue
+++ b/src/components/charts/ChartController.vue
@@ -3,14 +3,23 @@
   Description: Handles the display logic for the meter-data charts on the dashboard (both for the map-interface and building-list).
 -->
 <template>
-  <div
-    v-loading="loading || !chartData"
-    element-loading-background="rgba(0, 0, 0, 0.8)"
-    :element-loading-text="
-      batchStatus.active ? `Loading batch ${batchStatus.current} of ${batchStatus.total}…` : 'Loading…'
-    "
-    :style="`height: ${height}px; border-radius: 5px; overflow: hidden;`"
-  >
+  <div>
+    <el-alert
+      v-if="clampedStartDate"
+      :title="`No data available before ${clampedStartDate}. Showing from earliest available reading.`"
+      type="info"
+      :closable="true"
+      show-icon
+      class="data-clamp-alert"
+    />
+    <div
+      v-loading="loading || !chartData"
+      element-loading-background="rgba(0, 0, 0, 0.8)"
+      :element-loading-text="
+        batchStatus.active ? `Loading batch ${batchStatus.current} of ${batchStatus.total}…` : 'Loading…'
+      "
+      :style="`height: ${height}px; border-radius: 5px; overflow: hidden;`"
+    >
     <Linechart
       v-if="graphType === 1 && chartData && this.path !== 'map/building_35/block_175'"
       ref="Linechart"
@@ -77,6 +86,7 @@
     <el-col :span="24" class="NoData" :style="`height:${height}px;line-height:${height}px;`" v-if="graphType == 100"
       >Data Unavailable</el-col
     >
+    </div>
   </div>
 </template>
 <script>
@@ -208,6 +218,14 @@ export default {
       get() {
         return this.$store.getters['dataStore/batchStatus']
       }
+    },
+    clampedStartDate() {
+      if (!this.chartData?.datasets) return null
+      const firstDataset = this.chartData.datasets.find(d => d.data?.length > 0)
+      if (!firstDataset) return null
+      const actualStart = new Date(firstDataset.data[0].x)
+      if (actualStart > new Date(this.dateStart)) return actualStart.toDateString()
+      return null
     }
   },
   beforeUnmount() {
@@ -358,13 +376,11 @@ export default {
           return ' '
         }
 
-        const date1 = new Date(this.dateStart)
-        const date2 = new Date(this.dateEnd)
-        if (date1 && date2) {
-          return date1.toDateString() + ' to ' + date2.toDateString()
-        } else {
-          return ' '
-        }
+        const firstDataset = this.chartData?.datasets?.find(d => d.data?.length > 0)
+        if (!firstDataset) return ' '
+        const date1 = new Date(firstDataset.data[0].x)
+        const date2 = new Date(firstDataset.data[firstDataset.data.length - 1].x)
+        return date1.toDateString() + ' to ' + date2.toDateString()
       }
     },
     multipleTimePeriods: function (charts) {
@@ -457,6 +473,10 @@ export default {
   color: $color-black;
   font-weight: 800;
   font-size: 22px;
+}
+.data-clamp-alert {
+  margin-top: 16px;
+  margin-bottom: 8px;
 }
 .scaled-iframe {
   transform: scale(0.4);

--- a/src/components/map/BuildingModal.vue
+++ b/src/components/map/BuildingModal.vue
@@ -196,7 +196,8 @@ export default {
 .main {
   padding: 0;
   border-radius: 5px;
-  overflow: hidden;
+  height: 100%;
+  overflow-y: auto;
   background-color: rgb(26, 26, 26);
   box-shadow: -1px 1px 6px rgba(0, 0, 0, 0.6);
 }

--- a/src/components/map/Map.vue
+++ b/src/components/map/Map.vue
@@ -668,7 +668,8 @@ $sideMenu-width: 250px;
   padding: 0;
   position: absolute;
   width: 100%;
-  height: 100%;
+  height: calc(100vh - #{$nav-height});
+  overflow: hidden;
 }
 
 .el-menu-item {
@@ -684,6 +685,8 @@ $sideMenu-width: 250px;
   width: $sideMenu-width - 10px;
   padding-top: 0.5em;
   top: 175px;
+  max-height: calc(100vh - #{$nav-height} - 175px);
+  overflow-y: auto;
 }
 
 :deep(.el-menu-item-group__title) {

--- a/src/store/chart_modifiers/accumulated_real.js
+++ b/src/store/chart_modifiers/accumulated_real.js
@@ -100,6 +100,11 @@ export default class AccumulatedModifier {
         endKey = findClosest(dateKeysArray, i)
       }
 
+      // If both keys resolve to the same timestamp, no real data spans this interval
+      // (e.g. the entire bucket falls before the meter's first reading). Skip it
+      // rather than pushing a synthetic 0 to the chart.
+      if (startKey === endKey) continue
+
       try {
         const startValue = currentData.get(startKey)
         const endValue = currentData.get(endKey)


### PR DESCRIPTION
Addresses Issue #530 

### Summary 

Fixes two bugs that occur when a user requests data for a date range starting before a meter's first available reading.

### Root Cause

Zero-fill bug (accumulated_real.js): The postGetData loop iterates over the full requested date range and uses findClosest() to snap each bucket's boundary timestamps to the nearest real reading. When an entire bucket falls before the meter's first reading, both boundaries snap to the same timestamp, producing a difference of 0, which was silently pushed to the chart as a valid 0.00 data point.

Wrong X-axis label (ChartController.vue): The buildLabel function used this.dateStart / this.dateEnd from Vuex state — the user's originally requested range — rather than the timestamps of the actual rendered data points.

### Changes

- src/store/chart_modifiers/accumulated_real.js: Added a startKey === endKey guard that skips any bucket where both boundary keys resolve to the same timestamp, preventing synthetic zero values from being plotted.
- src/components/charts/ChartController.vue:
  - buildLabel now derives the X-axis date range from the first and last rendered data points instead of Vuex state.
  - Added a clampedStartDate computed property that detects when the actual data start is later than the requested start.
  - Added an el-alert banner that appears above the chart in this case, reading: "No data available before [date]. Showing from earliest available reading."