### PR TITLE
Add /solarrecent endpoint for last logged solar meter dates

### DIFF
--- a/backend/app/solar_recent.js
+++ b/backend/app/solar_recent.js
@@ -1,0 +1,8 @@
+import Response from '/opt/nodejs/response.js'
+import SolarRecent from '/opt/nodejs/models/solar_recent.js'
+
+export async function get(event, context) {
+  let response = new Response(event)
+  response.body = JSON.stringify(await new SolarRecent().get())
+  return response
+}

--- a/backend/dependencies/nodejs/models/solar_recent.js
+++ b/backend/dependencies/nodejs/models/solar_recent.js
@@ -1,0 +1,23 @@
+/*
+ * Filename: models/solar_recent.js
+ * Description: Defines SolarRecent class and methods to interact with the database.
+ */
+import { connect, query } from '/opt/nodejs/sql-access.js'
+
+class SolarRecent {
+  async get() {
+    await connect()
+
+    // Consumed by automated-jobs/SEC/readSEC.js to resume scraping from the day
+    // after each meter's last logged reading, rather than only fetching yesterday.
+    // Returns raw time_seconds; the caller converts to a Pacific calendar date.
+    return query(
+      `SELECT MeterID, MAX(time) as time, MAX(time_seconds) as time_seconds
+      FROM Solar_Meters
+      GROUP BY MeterID
+      ORDER BY MeterID ASC;`
+    )
+  }
+}
+
+export default SolarRecent

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -214,6 +214,21 @@ Resources:
           Properties:
             Path: /pprecent
             Method: get
+  solarRecent:
+    Type: AWS::Serverless::Function
+    Properties:
+      MemorySize: 128
+      CodeUri: app/
+      Handler: solar_recent.get
+      Layers:
+        - !Ref LambdaCommonLayer
+        - !Ref EnergyModelLayer
+      Events:
+        Building:
+          Type: Api
+          Properties:
+            Path: /solarrecent
+            Method: get
   EnergyModelLayer:
     Type: AWS::Serverless::LayerVersion
     Properties:


### PR DESCRIPTION
## Summary
- Add `GET /solarrecent`, returning the last logged reading for every solar meter

## Root Cause
- `automated-jobs/SEC/readSEC.js` only ever ingested yesterday. A failed run silently
lost that day forever. Pacific Power already solves this with `GET /pprecent`; solar
had no equivalent.

## Changes
- **`backend/dependencies/nodejs/models/solar_recent.js`**: `SolarRecent.get()` returns
  `MeterID, MAX(time), MAX(time_seconds)` grouped by `MeterID` from `Solar_Meters`.
- **`backend/app/solar_recent.js`**: handler, mirroring `app/pacific_power_recent.js`.
- **`backend/template.yaml`**: `solarRecent` function on `GET /solarrecent`. Unauthenticated,
  matching `/pprecent` and `/ppexclude`.