### PR TITLE
Fix data availability alert firing on every chart

### DIFF
--- a/src/components/charts/ChartController.vue
+++ b/src/components/charts/ChartController.vue
@@ -122,6 +122,7 @@ export default {
       loading: true,
       abortController: null, // used to abort ongoing requests
       chartData: null,
+      loadedQuery: null, // request parameters the current chartData was fetched with
       watchTimeout: null,
       colors: ['#4A773C', '#00859B', '#FFB500', '#AA9D2E', '#D3832B', '#0D5257', '#7A6855', '#C4D6A4']
     }
@@ -220,26 +221,13 @@ export default {
         return this.$store.getters['dataStore/batchStatus']
       }
     },
-    intervalUnit: {
-      get() {
-        return this.$store.getters[this.path + '/intervalUnit']
-      }
-    },
-    dateInterval: {
-      get() {
-        return this.$store.getters[this.path + '/dateInterval']
-      }
-    },
-    // Metering point of the first chart in this block (e.g. 'periodic_real_in')
-    point: {
-      get() {
-        const charts = this.$store.getters[this.path + '/charts']
-        if (!charts?.length) return null
-        return this.$store.getters[charts[0].path + '/point']
-      }
-    },
     // Date the first plotted point starts covering, or null if the data reaches
     // back to the requested start date.
+    //
+    // Reads the request parameters from loadedQuery (snapshotted when the fetch
+    // was dispatched) rather than the live store getters, so the alert always
+    // reflects the chart currently on screen. Comparing stale chartData against
+    // an already-updated dateStart would flash the alert while a new range loads.
     //
     // The chart modifiers stamp a point with the END of the interval it covers
     // (e.g. a day of usage is stamped with the following midnight), so the first
@@ -248,17 +236,16 @@ export default {
     // Monthly periodic_real points are the exception: they are already stamped
     // with the start of the month they cover.
     clampedStartDate() {
-      if (!this.chartData?.datasets) return null
+      if (!this.loadedQuery || !this.chartData?.datasets) return null
       const firstDataset = this.chartData.datasets.find(d => d.data?.length > 0)
       if (!firstDataset) return null
 
+      const { dateStart, dateInterval, intervalUnit, point } = this.loadedQuery
       const firstPoint = DateTime.fromJSDate(new Date(firstDataset.data[0].x))
-      const stampedAtIntervalStart = this.intervalUnit === 'month' && this.point?.startsWith('periodic_real')
-      const dataStart = stampedAtIntervalStart
-        ? firstPoint
-        : firstPoint.minus({ [`${this.intervalUnit}s`]: this.dateInterval })
+      const stampedAtIntervalStart = intervalUnit === 'month' && point?.startsWith('periodic_real')
+      const dataStart = stampedAtIntervalStart ? firstPoint : firstPoint.minus({ [`${intervalUnit}s`]: dateInterval })
 
-      if (dataStart.toMillis() > this.dateStart) return dataStart.toJSDate().toDateString()
+      if (dataStart.toMillis() > dateStart) return dataStart.toJSDate().toDateString()
       return null
     }
   },
@@ -288,6 +275,18 @@ export default {
 
       this.loading = true
 
+      // Snapshot the request parameters now so clampedStartDate can compare the
+      // fetched data against the range it was requested for, not whatever the
+      // store holds by the time it recomputes
+      const charts = this.$store.getters[this.path + '/charts']
+      const query = {
+        dateStart: this.dateStart,
+        dateInterval: this.$store.getters[this.path + '/dateInterval'],
+        intervalUnit: this.$store.getters[this.path + '/intervalUnit'],
+        // Metering point of the first chart in this block (e.g. 'periodic_real_in')
+        point: charts?.length ? this.$store.getters[charts[0].path + '/point'] : null
+      }
+
       try {
         const data = await this.$store.dispatch(this.path + '/getData', { signal })
         // Set the unit (metric type) for each dataset
@@ -296,6 +295,7 @@ export default {
         })
         // Set the chart data
         this.chartData = data
+        this.loadedQuery = query
         // Set the chart options
         this.$nextTick(() => {
           if (
@@ -333,6 +333,7 @@ export default {
           this.chartData = {
             datasets: []
           }
+          this.loadedQuery = null
         }
       } finally {
         if (!signal.aborted) {

--- a/src/components/charts/ChartController.vue
+++ b/src/components/charts/ChartController.vue
@@ -90,6 +90,7 @@
   </div>
 </template>
 <script>
+import { DateTime } from 'luxon'
 import Linechart from '@/components/charts/Linechart.vue'
 import Barchart from '@/components/charts/Barchart.vue'
 
@@ -219,12 +220,45 @@ export default {
         return this.$store.getters['dataStore/batchStatus']
       }
     },
+    intervalUnit: {
+      get() {
+        return this.$store.getters[this.path + '/intervalUnit']
+      }
+    },
+    dateInterval: {
+      get() {
+        return this.$store.getters[this.path + '/dateInterval']
+      }
+    },
+    // Metering point of the first chart in this block (e.g. 'periodic_real_in')
+    point: {
+      get() {
+        const charts = this.$store.getters[this.path + '/charts']
+        if (!charts?.length) return null
+        return this.$store.getters[charts[0].path + '/point']
+      }
+    },
+    // Date the first plotted point starts covering, or null if the data reaches
+    // back to the requested start date.
+    //
+    // The chart modifiers stamp a point with the END of the interval it covers
+    // (e.g. a day of usage is stamped with the following midnight), so the first
+    // point's x-value sits one interval after the data it represents. Comparing
+    // that x-value directly against dateStart would report a gap on every chart.
+    // Monthly periodic_real points are the exception: they are already stamped
+    // with the start of the month they cover.
     clampedStartDate() {
       if (!this.chartData?.datasets) return null
       const firstDataset = this.chartData.datasets.find(d => d.data?.length > 0)
       if (!firstDataset) return null
-      const actualStart = new Date(firstDataset.data[0].x)
-      if (actualStart > new Date(this.dateStart)) return actualStart.toDateString()
+
+      const firstPoint = DateTime.fromJSDate(new Date(firstDataset.data[0].x))
+      const stampedAtIntervalStart = this.intervalUnit === 'month' && this.point?.startsWith('periodic_real')
+      const dataStart = stampedAtIntervalStart
+        ? firstPoint
+        : firstPoint.minus({ [`${this.intervalUnit}s`]: this.dateInterval })
+
+      if (dataStart.toMillis() > this.dateStart) return dataStart.toJSDate().toDateString()
       return null
     }
   },


### PR DESCRIPTION
## Summary
- Fixes #571: the "No data available before X" alert appeared on every building, and named a date one day after the selected From Date.
- The alert now appears only when the data genuinely starts after the requested From Date, and names the first day that actually has data.

## Root Cause
The chart modifiers stamp each point with the **end** of the interval it covers. `periodic_real.js` returns `bucketStart.plus({ days: 1 })` as the day bucket key, and `accumulated_real.js` pushes `i + delta`. But `clampedStartDate` compared that end-stamp directly against the requested `dateStart`. The first point is always one interval later than the data it represents, so the condition was true on essentially every chart, and the date shown was always one interval (one day) late.

Confirmed against production data for Boathouse (meter 166, `periodic_real_in`): its earliest reading is `Tue May 12 2026 23:59:59`, inside the requested window starting `May 12 22:45` — nothing missing — yet the alert fired claiming "No data available before Wed May 13 2026".

## Changes
- **`src/components/charts/ChartController.vue`**: `clampedStartDate` now derives the date the first point *starts covering* (subtracting one interval with Luxon, so month lengths and DST are handled) and compares that against `dateStart`. Monthly `periodic_real` buckets are the one exception. `getMonthBucketKey` stamps them at the bucket *start*, so nothing is subtracted there; this inconsistency between the modifiers is documented in a comment. Adds `intervalUnit`, `dateInterval`, and `point` computed getters (all already exist as store getters).

## Test Plan
- [x] Click through several buildings on the default view — no alert appears.
- [x] Set a From Date earlier than a meter's first reading — the alert appears and names the first day with data, matching the chart's left edge.
- [x] Set a From Date well inside the data range — no alert.
- [x] Check a monthly-interval chart on a solar/periodic meter — the alert names the correct first month.