### PR TITLE
Resolve latest LambdaCommonLayer in CI and auto-bump the pin

### DIFF
--- a/.github/workflows/layer-bump.yml
+++ b/.github/workflows/layer-bump.yml
@@ -1,0 +1,73 @@
+name: Bump LambdaCommonLayer
+on:
+  schedule:
+    # Mondays at 09:00 UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+jobs:
+  bump-layer:
+    name: Open PR bumping LambdaCommonLayer
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+    - uses: actions/checkout@v6
+    - uses: aws-actions/configure-aws-credentials@v5
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+    - name: Resolve latest LambdaCommonLayer
+      id: layer
+      run: |
+        # --no-paginate is required: the CLI otherwise auto-paginates and applies
+        # --query per page, emitting one ARN per page instead of just the latest.
+        LATEST=$(aws lambda list-layer-versions \
+          --layer-name LambdaCommonLayer --region us-west-2 --no-paginate \
+          --query 'LayerVersions[0].LayerVersionArn' --output text | head -1)
+        if [ -z "$LATEST" ] || [ "$LATEST" = "None" ]; then
+          echo "::error::Could not resolve latest LambdaCommonLayer version"
+          exit 1
+        fi
+        echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+    - name: Update pinned layer in template.yaml
+      id: bump
+      run: |
+        PINNED=$(grep -oE 'arn:aws:lambda:[a-z0-9-]+:[0-9]+:layer:LambdaCommonLayer:[0-9]+' backend/template.yaml | head -1)
+        LATEST="${{ steps.layer.outputs.latest }}"
+        if [ "$PINNED" = "$LATEST" ]; then
+          echo "Already on the latest layer ($PINNED); nothing to do."
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+        sed -i -E "s|arn:aws:lambda:[a-z0-9-]+:[0-9]+:layer:LambdaCommonLayer:[0-9]+|$LATEST|" backend/template.yaml
+        echo "changed=true" >> "$GITHUB_OUTPUT"
+        echo "pinned=$PINNED" >> "$GITHUB_OUTPUT"
+        echo "version=${LATEST##*:}" >> "$GITHUB_OUTPUT"
+    - name: Open pull request
+      if: steps.bump.outputs.changed == 'true'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        # NOTE: PRs opened with the default GITHUB_TOKEN do not trigger other
+        # workflows, so "S3 Test Build" will not run on this PR automatically.
+        # Close and reopen the PR to kick CI, or add a LAYER_BUMP_TOKEN secret
+        # (a PAT with repo scope) and CI will run on its own.
+        token: ${{ secrets.LAYER_BUMP_TOKEN || secrets.GITHUB_TOKEN }}
+        # Fixed branch name so repeated runs update this PR instead of stacking duplicates.
+        branch: chore/bump-lambda-common-layer
+        base: master
+        commit-message: 'Bump LambdaCommonLayer to version ${{ steps.bump.outputs.version }}'
+        title: 'Bump LambdaCommonLayer to version ${{ steps.bump.outputs.version }}'
+        body: |
+          A newer version of the shared Lambda layer is available.
+
+          - Pinned: `${{ steps.bump.outputs.pinned }}`
+          - Latest: `${{ steps.layer.outputs.latest }}`
+
+          This default applies to freshly created stacks (test builds). The production
+          `energy` stack keeps its existing parameter value across deploys, so merging
+          this does not by itself move production onto the new layer.
+
+          Opened automatically by `.github/workflows/layer-bump.yml`.

--- a/.github/workflows/test-build-s3.yml
+++ b/.github/workflows/test-build-s3.yml
@@ -64,6 +64,26 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: us-west-2
+    - name: Resolve latest LambdaCommonLayer
+      id: layer
+      run: |
+        # --no-paginate is required: the CLI otherwise auto-paginates and applies
+        # --query per page, emitting one ARN per page instead of just the latest.
+        LATEST=$(aws lambda list-layer-versions \
+          --layer-name LambdaCommonLayer --region us-west-2 --no-paginate \
+          --query 'LayerVersions[0].LayerVersionArn' --output text | head -1)
+        if [ -z "$LATEST" ] || [ "$LATEST" = "None" ]; then
+          echo "::error::Could not resolve latest LambdaCommonLayer version"
+          exit 1
+        fi
+        echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
+    - name: Check pinned layer is current
+      working-directory: backend
+      run: |
+        PINNED=$(grep -oE 'arn:aws:lambda:[a-z0-9-]+:[0-9]+:layer:LambdaCommonLayer:[0-9]+' template.yaml | head -1)
+        if [ "$PINNED" != "${{ steps.layer.outputs.latest }}" ]; then
+          echo "::warning file=backend/template.yaml::LambdaCommonLayer pins $PINNED but latest is ${{ steps.layer.outputs.latest }}. The layer-bump workflow opens a PR for this."
+        fi
     - name: Validate
       working-directory: backend
       run: |

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -37,8 +37,11 @@ Globals:
       MaxAge: 600
       AllowCredentials: True
 Parameters:
-  # Lambda Common layer ARN to use for energy dashboard functions (this is only used for test builds)
-  # Production builds automatically use the latest version of the layer
+  # Lambda Common layer ARN to use for energy dashboard functions.
+  # This default only applies to stacks created fresh (test builds) and to local `sam` runs.
+  # The production `energy` stack keeps whatever value it already has: API-deploy.yml runs
+  # `sam deploy` with no --parameter-overrides, so SAM sends UsePreviousValue for this parameter.
+  # The layer-bump workflow opens a PR when a newer version is published.
   LambdaCommonLayer:
     Type: String
     Default: arn:aws:lambda:us-west-2:005937143026:layer:LambdaCommonLayer:107


### PR DESCRIPTION
Addresses Issue #425 

## Summary
- CI now resolves the newest `LambdaCommonLayer` version from AWS at run time and warns when `template.yaml` has fallen behind
- New weekly workflow opens a PR to bump the pin
- Corrected a comment in `template.yaml` that described production behavior inaccurately

## Root Cause
`backend/template.yaml` pins the shared Lambda layer ARN as a CloudFormation parameter default,
bumped by hand — git history shows `96 → 97 → 103 → 97 → 107`, each buried in an unrelated
feature PR. It currently reads `107` while the latest published version is `110`.

Nothing surfaced the drift. The comment above it claimed "Production builds automatically use the
latest version of the layer," which is not what happens: `API-deploy.yml` runs `sam deploy` with no
`--parameter-overrides`, so against an existing stack SAM sends `UsePreviousValue=true` and `energy`
keeps whatever it already had (110, set out-of-band). The template default is never read.

The default therefore only takes effect on a stack created *fresh*, which is exactly a test build.
A test stack stood up today would come up three versions behind production.

## Changes
- **`.github/workflows/test-build-s3.yml`**: two steps in `deploy-sam` — resolve the latest layer
  version via `aws lambda list-layer-versions` (fails the job if the lookup returns nothing), then
  compare against the pin and emit a `::warning::` annotation on drift. Warning only, so a newly
  published layer never red-Xs an unrelated PR.
- **`.github/workflows/layer-bump.yml`** (new): weekly cron + `workflow_dispatch`. Rewrites the pin
  with `sed` and opens a PR via `peter-evans/create-pull-request@v7` on a fixed branch, so repeated
  runs update one PR instead of stacking duplicates.
- **`backend/template.yaml`**: replaced the misleading comment with an accurate one. The pinned
  value is unchanged at `107` — the bump workflow handles that in its own PR.

`API-deploy.yml` is deliberately untouched. Production stays on 110 via `UsePreviousValue` until
someone merges a bump.

### Note on `--no-paginate`
The AWS CLI auto-paginates `list-layer-versions` (~50 versions) and applies `--query` **per page**,
emitting one ARN per page rather than just the latest. Without the flag the command returns three
ARNs, which breaks the `sed` in the bump workflow. `head -1` is a second guard.

## Test Plan
- [x] `Validate Serverless API` passes on this PR
- [x] "Resolve latest LambdaCommonLayer" succeeds — CI creds hold `lambda:ListLayerVersions`
      (confirmed via `simulate-principal-policy`, but this is the first live run)
- [x] Drift warning appears as an annotation citing `backend/template.yaml`
- [ ] After merge: run `layer-bump.yml` via **Run workflow**; confirm it opens a PR changing only
      `107` → `110`
- [ ] Re-run it; confirm it updates that PR rather than opening a second
- [ ] Confirm `aws cloudformation describe-stacks --stack-name energy --query 'Stacks[0].Parameters'`
      still reads `110` after the next `master` deploy