### PR TITLE
Fix chart clipping when data-availability alert is shown

### DIFF
--- a/src/components/building_view/BuildingPanel.vue
+++ b/src/components/building_view/BuildingPanel.vue
@@ -130,7 +130,11 @@ export default {
       style: {
         display: 'inline-block',
         width: 'calc(100% - 3em)',
-        height: '400px',
+        // 100% rather than a fixed height so the canvas shrinks with its box when
+        // ChartController shows the data-availability alert. border-box keeps the
+        // padding below inside that 100% (there is no global box-sizing reset).
+        height: '100%',
+        'box-sizing': 'border-box',
         'margin-right': '0.5em',
         'margin-left': '0.5em',
         'padding-right': '1em',

--- a/src/components/campaigns/Campaign.vue
+++ b/src/components/campaigns/Campaign.vue
@@ -44,7 +44,8 @@
               :styleC="{
                 display: 'inline-block',
                 width: '98%',
-                height: '340px',
+                height: '100%',
+                'box-sizing': 'border-box',
                 'padding-right': '0.5em',
                 'padding-left': '0.5em',
                 'padding-top': '1em'

--- a/src/components/charts/ChartController.vue
+++ b/src/components/charts/ChartController.vue
@@ -3,7 +3,7 @@
   Description: Handles the display logic for the meter-data charts on the dashboard (both for the map-interface and building-list).
 -->
 <template>
-  <div>
+  <div class="chart-controller" :style="`height: ${height}px;`">
     <el-alert
       v-if="clampedStartDate"
       :title="`No data available before ${clampedStartDate}. Showing from earliest available reading.`"
@@ -13,12 +13,13 @@
       class="data-clamp-alert"
     />
     <div
+      class="chart-box"
       v-loading="loading || !chartData"
       element-loading-background="rgba(0, 0, 0, 0.8)"
       :element-loading-text="
         batchStatus.active ? `Loading batch ${batchStatus.current} of ${batchStatus.total}…` : 'Loading…'
       "
-      :style="`height: ${height}px; border-radius: 5px; overflow: hidden;`"
+      style="border-radius: 5px; overflow: hidden"
     >
       <Linechart
         v-if="graphType === 1 && chartData && this.path !== 'map/building_35/block_175'"
@@ -503,6 +504,26 @@ export default {
 }
 </script>
 <style lang="scss" scoped>
+// The root is pinned to the full `height` prop (inline, in the template) so this
+// component's footprint never changes, whether or not the alert is showing.
+// Consumers drop it into fixed-height containers -- BuildingModal's carousel is a
+// hard 250px with overflow: hidden -- so an alert that added its own height on top
+// would push the chart out of the container and get its x-axis clipped. Instead the
+// alert takes its natural height here and .chart-box flexes into what is left.
+//
+// Keep this a single root element: consumers pass class="chart", which Vue can only
+// auto-inherit onto a single-root component.
+.chart-controller {
+  display: flex;
+  flex-direction: column;
+}
+// min-height: 0 is required. Flex items default to min-height: auto, which refuses
+// to shrink below the content's intrinsic size, so without it the chart keeps its
+// full height and overflows the container again.
+.chart-box {
+  flex: 1 1 auto;
+  min-height: 0;
+}
 .NoData {
   text-align: center;
   color: $color-black;

--- a/tests/unit/components/chart_controller.spec.js
+++ b/tests/unit/components/chart_controller.spec.js
@@ -152,3 +152,50 @@ describe('ChartController "no data available" alert', () => {
     expect(alert.text()).toContain('No data available before Wed Apr 15 2026')
   })
 })
+
+/**
+ * Consumers drop ChartController into fixed-height containers (BuildingModal's
+ * carousel is a hard 250px with overflow: hidden), so the alert must never add
+ * height on top of the chart -- it has to come out of the same box. jsdom has no
+ * layout engine, so these lock the DOM contract that makes that work rather than
+ * measuring pixels; the visual result needs a browser.
+ */
+describe('ChartController layout footprint', () => {
+  const withAlert = () =>
+    createTestStore({
+      dateStart: localDate(2026, 3, 27),
+      data: dailyBuckets(localDate(2026, 4, 12), 30)
+    })
+
+  const withoutAlert = () =>
+    createTestStore({
+      dateStart: localDate(2026, 4, 12, 22, 45),
+      data: dailyBuckets(localDate(2026, 4, 12), 30)
+    })
+
+  it('pins the root to the full height prop whether or not the alert shows', async () => {
+    for (const store of [withAlert(), withoutAlert()]) {
+      const wrapper = await mountController(store)
+
+      // mountController passes height: 400
+      expect(wrapper.element.style.height).toBe('400px')
+    }
+  })
+
+  it('never puts the fixed height on the chart box, so it can flex', async () => {
+    const wrapper = await mountController(withAlert())
+
+    // The height belongs to the root only; a fixed height here would push the
+    // chart past the container and reintroduce the clipping.
+    expect(wrapper.find('.chart-box').element.style.height).toBe('')
+  })
+
+  it('keeps the alert and the chart box as siblings inside the root', async () => {
+    const wrapper = await mountController(withAlert())
+
+    const children = Array.from(wrapper.element.children)
+    expect(children).toHaveLength(2)
+    expect(children[0].classList.contains('data-clamp-alert')).toBe(true)
+    expect(children[1].classList.contains('chart-box')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Stops the data-availability alert from clipping the bottom off every chart it appears above.
- Reported against the map's building modal (Sackett Hall, 60 Days), where the x-axis and its tick labels vanished behind the Compare / View Full Graph buttons.
- Fixed once in `ChartController`, so all four consumers are covered rather than patching each container.

## Root Cause

The alert added in #567 renders as a sibling *above* the chart box, and nothing in the layout accounts for the height it takes.

In the modal that means roughly 354px of content — the alert (16px + 8px margins plus ~80px of two-line text at the modal's 420px width) on top of a chart wrapper hardcoded to `height: 250px` — inside a `.graph` carousel that is a hard `height: 250px; overflow: hidden`. Element Plus absolutely positions `.el-carousel__item`, so content cannot drive the height and the bottom ~104px is simply clipped away. The buttons sit flush against the clip line, which is what makes them look like they are covering the graph.

**This is clipping, not a z-index overlap** — a stacking fix would have changed nothing.

It is also not modal-specific. Every consumer hardcodes a chart height inside a fixed-height ancestor, so each broke differently:

| Consumer | Chart height | Fixed ancestor | Failure |
|---|---|---|---|
| `map/BuildingModal.vue` | 250 | `.graph` 250px, `overflow: hidden` | chart bottom clipped (reported) |
| `map/BuildingCompareModal.vue` | 225 | `.innerContent` 100%, `overflow: hidden` | buttons pushed out of view |
| `building_view/BuildingPanel.vue` | 430 / 550 | `.buildingPanel` `calc(400px + 8em)` | chart spills onto the next panel |
| `campaigns/Campaign.vue` | 362 | `.chartArea` `calc(450px + 5em)` | chart spills past the section |

## Changes

- **`src/components/charts/ChartController.vue`**: the root is now pinned to the full `height` prop and laid out as a flex column; the fixed height moved off the inner wrapper, which became `.chart-box` with `flex: 1 1 auto; min-height: 0`. The alert takes its natural height and the chart flexes into what is left, so the component's external footprint is identical whether or not the alert shows — every existing container keeps working untouched. No measurement, no `ResizeObserver`, no child-to-parent coupling: `Linechart` already runs `responsive: true, maintainAspectRatio: false`, so Chart.js re-sizes the canvas itself when the alert appears or is dismissed.

- **`src/components/campaigns/Campaign.vue`**, **`src/components/building_view/BuildingPanel.vue`**: `styleC` height `340px`/`400px` → `100%` so the canvas can shrink with its box instead of clipping. Both also gain `box-sizing: border-box` — there is no global border-box reset in this app (Element Plus's `index.scss` only pulls in `base.scss`, and the two `*{box-sizing:border-box}` rules in its dist are scoped to drawer and table), which is exactly why these two previously sized the canvas *under* the box to leave room for their `padding-top: 1em`. Without border-box a bare `100%` would overflow by 16px.

- **`tests/unit/components/chart_controller.spec.js`**: three structural tests covering the root's pinned height, the absence of a fixed height on `.chart-box`, and the alert/chart-box sibling structure. jsdom has no layout engine, so these lock the DOM contract that makes the fix work; the visual result still needs a browser.

## Notes for reviewers

- Campaign and BuildingPanel charts each gain roughly 20-30px of height from the `box-sizing` change. That is correct behaviour — the canvas now fills its box exactly — but it is a visible difference worth a look.
- `ChartController.vue`'s `maxTicksLimit` still derives from the nominal `height`, so while the alert shows the y-axis is sized for a slightly taller box than it has. Chart.js auto-skips overlapping ticks, so it degrades gracefully; fixing it properly would need the measured box height, which this approach deliberately avoids. Left alone unless the shorter modal chart looks crowded.
- Keep `ChartController`'s template single-root. All four consumers pass `class="chart"`, and Vue only auto-inherits attributes onto a single-root component — a stray template comment turns it into a fragment and silently drops that class. There is a note in the style block.

## Test Plan

- [x] `npm run test:unit` — 9 passed / 4 files
- [x] `npm run format` — prettier clean, eslint no errors
- [x] Map modal: open Sackett Hall, select **60 Days**. Alert visible, full chart below it *including the x-axis and its date tick labels*, buttons clear of the chart. Dismiss the alert → chart grows back to 250px.
- [x] Compare modal: a building whose data starts mid-range — buttons must stay on screen.
- [x] `/building/:id` panel: chart must not overlap the panel below.
- [x] Campaign page: chart must not spill past the section.
- [x] No-alert regression: a building with full data in all four views should look pixel-identical to before.
