### PR TITLE
Compress and revalidate /allbuildings responses

### DIFF
--- a/backend/app/building.js
+++ b/backend/app/building.js
@@ -4,11 +4,63 @@
  */
 const { default: Building } = await import('/opt/nodejs/models/building.js')
 import Response from '/opt/nodejs/response.js'
+import { createHash } from 'crypto'
+
+// The frontend refetches this ~260 KB payload on every page load, but the data only
+// changes when a building or meter is added/edited.
+//
+// max-age=0 deliberately means "never serve this without checking" -- there is no
+// staleness window, so a change is visible on the next navigation rather than after
+// some timeout. stale-while-revalidate is what buys the speed: the browser paints
+// from cache immediately and refreshes in the background, instead of blocking on the
+// request. Browsers without stale-while-revalidate support (Firefox) fall back to a
+// blocking revalidation, which the ETag below turns into a ~300 byte 304.
+//
+// Do not swap this for a non-zero max-age without a way to invalidate: buildings are
+// currently edited by direct SQL against prod, so nothing in the app can bust the
+// cache after a write.
+const CACHE_CONTROL = 'max-age=0, stale-while-revalidate=86400'
+
+// Header casing is not guaranteed across API Gateway payload format versions.
+function getHeader(event, name) {
+  const headers = event.headers || {}
+  const key = Object.keys(headers).find(k => k.toLowerCase() === name)
+  return key === undefined ? undefined : headers[key]
+}
+
+// If-None-Match is a comma-separated list and entries may be weak validators (W/"…").
+function matchesETag(ifNoneMatch, etag) {
+  if (!ifNoneMatch) return false
+  if (ifNoneMatch.trim() === '*') return true
+  return ifNoneMatch
+    .split(',')
+    .map(candidate => candidate.trim().replace(/^W\//, ''))
+    .includes(etag)
+}
 
 export async function all(event, context) {
   let response = new Response(event)
-  response.body = JSON.stringify((await Building.all()).map(o => o.data))
+  const body = JSON.stringify((await Building.all()).map(o => o.data))
+  const etag = `"${createHash('sha1').update(body).digest('base64')}"`
+
+  response.headers['Cache-Control'] = CACHE_CONTROL
+  response.headers['ETag'] = etag
+  // Response reflects the request's Origin into Access-Control-Allow-Origin, so a
+  // cached entry is only valid for the origin that requested it. Accept-Encoding is
+  // listed because API Gateway now varies the body by compression.
+  response.headers['Vary'] = 'Origin, Accept-Encoding'
+
+  // Skips re-sending the payload once the client already has this exact copy. The
+  // query and serialization still run -- the body is what the ETag is computed from
+  // -- so this cuts transfer, not Lambda time.
+  if (matchesETag(getHeader(event, 'if-none-match'), etag)) {
+    response.statusCode = 304
+    response.body = ''
+    return response
+  }
+
   response.headers['Content-Type'] = 'application/json'
+  response.body = body
   return response
 }
 

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -10,6 +10,11 @@ Globals:
     Timeout: 15
     Runtime: nodejs18.x
   Api:
+    # Gzip responses over 1 KB when the client sends Accept-Encoding. /allbuildings
+    # is ~260 KB of JSON that was going out uncompressed on every page load; it
+    # compresses to ~25 KB. Applies to every route, so the large /data and
+    # /multiMeterData payloads benefit too.
+    MinimumCompressionSize: 1024
     # enable CORS; to make more specific, change the origin wildcard
     # to a particular domain name, e.g. "'www.example.com'"
     Cors:

--- a/backend/tests/map.spec.js
+++ b/backend/tests/map.spec.js
@@ -33,4 +33,50 @@ describe('Testing map.module.js related API endpoints...', () => {
       throw new Error(corsResult.reason)
     }
   })
+
+  it('/allbuildings is revalidated rather than served from a staleness window', async () => {
+    // max-age must stay 0 -- buildings are edited by direct SQL, so nothing in the
+    // app can invalidate a cached copy. Any non-zero value silently delays admin
+    // changes by that long.
+    expect(response.headers['Cache-Control']).toContain('max-age=0')
+    expect(response.headers['Cache-Control']).toContain('stale-while-revalidate=')
+  })
+
+  it('/allbuildings varies on Origin so a cached copy cannot leak across origins', async () => {
+    // Response echoes the request Origin into Access-Control-Allow-Origin.
+    expect(response.headers['Vary']).toContain('Origin')
+    expect(response.headers['Vary']).toContain('Accept-Encoding')
+  })
+
+  it('/allbuildings returns a stable ETag across identical requests', async () => {
+    const second = await all(MOCK_REQUEST_EVENT)
+    expect(response.headers['ETag']).toBeTruthy()
+    expect(second.headers['ETag']).toBe(response.headers['ETag'])
+  })
+
+  it('/allbuildings answers 304 with no body when the client already has that ETag', async () => {
+    const conditional = await all({
+      headers: { ...MOCK_REQUEST_EVENT.headers, 'If-None-Match': response.headers['ETag'] }
+    })
+    expect(conditional.statusCode).toBe(304)
+    expect(conditional.body).toBe('')
+    // A 304 still has to carry the validator and the caching directives.
+    expect(conditional.headers['ETag']).toBe(response.headers['ETag'])
+    expect(conditional.headers['Cache-Control']).toBe(response.headers['Cache-Control'])
+  })
+
+  it('/allbuildings tolerates weak validators and multi-value If-None-Match', async () => {
+    const conditional = await all({
+      headers: { ...MOCK_REQUEST_EVENT.headers, 'if-none-match': `"stale-one", W/${response.headers['ETag']}` }
+    })
+    expect(conditional.statusCode).toBe(304)
+  })
+
+  it('/allbuildings sends the full body when the ETag does not match', async () => {
+    const conditional = await all({
+      headers: { ...MOCK_REQUEST_EVENT.headers, 'If-None-Match': '"not-the-current-etag"' }
+    })
+    expect(conditional.statusCode).toBe(200)
+    expect(JSON.parse(conditional.body).length).toBeGreaterThan(5)
+  })
 })


### PR DESCRIPTION
## Summary

- `/allbuildings` was being served **uncompressed and uncached** on every single page load: 262.9 KB of JSON blocking first paint on both the map and the buildings tab, re-downloaded in full every time.
- Enables API Gateway gzip, which takes that payload to **~25 KB (-90%)**.
- Adds an `ETag` and a revalidate-always `Cache-Control`, so repeat loads paint from cache instead of waiting on the network.
- No staleness window: an admin's change is visible on the next navigation, not after a timeout.

## Root Cause

Measured against production:

```
GET /allbuildings
Content-Length: 269246
(no Content-Encoding — even when the client sends "Accept-Encoding: gzip, br")
(no Cache-Control, no ETag, no Last-Modified)
```

`Globals.Api` in `backend/template.yaml` had no `MinimumCompressionSize`, so API Gateway never compressed anything, and the handler set no caching headers. The payload compresses extremely well — it is highly repetitive JSON:

| | size |
|---|---|
| today (raw) | 262.9 KB |
| gzip -9 | **25.2 KB** (-90.4%) |
| brotli q5 | 22.1 KB |

Worth noting for anyone tempted to slim the payload instead: meter groups and meters are 64% of the *raw* bytes, but dropping them only moves the gzipped size from 25.2 KB to 18.7 KB. Once compression is on, restructuring the response is not worth the churn.

## Changes

- **`backend/template.yaml`**: `MinimumCompressionSize: 1024` under `Globals.Api`. This is API-wide, so the large `/data` and `/multiMeterData` payloads benefit too — see the deployment note below.

- **`backend/app/building.js`**: `all()` now computes a SHA-1 `ETag` over the response body and sets `Cache-Control: max-age=0, stale-while-revalidate=86400` plus `Vary: Origin, Accept-Encoding`. A matching `If-None-Match` returns `304` with an empty body, keeping the validator and caching directives. Weak validators (`W/"…"`), multi-value lists, and `*` are all handled, and the header lookup is case-insensitive because header casing is not guaranteed across API Gateway payload format versions.

- **`backend/tests/map.spec.js`**: six new tests — `max-age=0` is present, `Vary` covers both dimensions, the ETag is stable across identical requests, a matching `If-None-Match` yields a bodied-less 304 that still carries the validator, weak/multi-value validators match, and a non-matching validator still returns the full body.

## Why `max-age=0` rather than a real freshness window

A non-zero `max-age` would silently delay admin changes by exactly that long, and there is **no way to invalidate it**: `template.yaml` exposes no building create/update route (only `/buildinggeojson` PUT for an automated job), so buildings are edited by direct SQL against prod and nothing in the application can bust a cached copy after a write.

`max-age=0` means the response is never served without checking, so there is no staleness window at all. The speed comes from `stale-while-revalidate` instead: the browser paints from cache with zero network wait and refreshes in the background. A change lands on the next navigation, or immediately on a hard refresh. Firefox does not implement `stale-while-revalidate` and falls back to a blocking revalidation, which the ETag turns into a ~300 byte 304 rather than 263 KB. Both paths are correct; only the paint timing differs.

There is a comment in the code warning against raising `max-age` without first adding an invalidation path.

## Known limits

- **The 304 saves transfer, not Lambda time.** The ETag is a hash of the body, so the DB query and serialization still run on every request. Cutting backend cost would need a cheap version/timestamp column to hash instead, which the schema does not have today.
- **`Vary: Origin` is load-bearing, not decorative.** `Response` (LambdaCommonLayer) reflects the request's `Origin` into `Access-Control-Allow-Origin`, so without it a shared cache could serve one origin another origin's CORS header.

## Test Plan

- [x] `cd backend && npm run test-local` — 15 passed / 3 files (`map.spec.js` 2 → 8 tests)
- [x] `sam validate` — valid SAM template
- [x] `npm run format` — prettier clean, eslint no errors
- [ ] **After deploy**, confirm compression is actually active — this cannot be verified pre-deploy:
      `curl -sD - -o /dev/null -H "Accept-Encoding: gzip" https://api.sustainability.oregonstate.edu/v2/energy/allbuildings | grep -i "content-encoding\|cache-control\|etag"`
      Expect `Content-Encoding: gzip`, `Cache-Control: max-age=0, stale-while-revalidate=86400`, and an `ETag`.
- [ ] Reload the dashboard twice with DevTools open: second load should show `304` for `/allbuildings` (or a cache hit), not a fresh 263 KB transfer.
- [ ] Sanity-check a large `/data` request still returns valid JSON now that compression is API-wide.
