### PR TITLE
Stop buildings tab blocking on OSM geometry fetch

### DIFF
--- a/src/components/building_list/BuildingList.vue
+++ b/src/components/building_list/BuildingList.vue
@@ -70,13 +70,24 @@ export default {
     }
   },
   async mounted() {
-    await this.$store.getters['map/promise']
-    if (this.$route.params.group && this.groups[this.$route.params.group]) {
-      this.openName = this.$route.params.group
-    } else {
-      this.openName = Object.keys(this.groups)[0]
+    try {
+      // dispatch rather than awaiting the map/promise getter directly: the getter is
+      // null until something else kicks the load off, and awaiting null resolves
+      // instantly onto an empty building list.
+      await this.$store.dispatch('map/loadMap')
+      if (this.$route.params.group && this.groups[this.$route.params.group]) {
+        this.openName = this.$route.params.group
+      } else {
+        this.openName = Object.keys(this.groups)[0]
+      }
+    } catch (err) {
+      // The groups watcher still populates the tabs if the data arrives later.
+      console.error('Could not load the building list:', err)
+    } finally {
+      // Always clear the spinner. Leaving it set on failure is what made the tab
+      // appear to hang indefinitely.
+      this.loading = false
     }
-    this.loading = false
   },
   computed: {
     buildingList: {

--- a/src/store/map.module.js
+++ b/src/store/map.module.js
@@ -92,17 +92,47 @@ const actions = {
         }
         await Promise.all(buildingPromises)
 
-        // fetch missing geoJSON data (if any)
-        const buildingMap = store.getters.buildingMap
-        const missingIds = Array.from(buildingMap.keys()).join(',')
-        if (missingIds.length > 0) {
-          await store.dispatch('loadGeoJSONData', missingIds)
-          buildingMap.clear() // clear the map to indicate that all missing geoJSON has been loaded
-        }
+        // Deliberately not awaited. Everything that awaits map/promise -- the
+        // buildings tab, the block and campaign modules, updateEnergySlopeColor --
+        // needs building and meter-group metadata, not geometry. The backfill below
+        // hits a third-party Overpass mirror whose latency swings from under a
+        // second to several, and axios allows it 72 seconds before giving up, so
+        // awaiting it here held the buildings tab on a spinner until campus polygons
+        // arrived and left it spinning for good if the mirror failed. The map picks
+        // the geometry up reactively as it lands.
+        store.dispatch('backfillGeoJSON')
       })()
       store.commit('promise', mapPromise)
     }
-    return store.getters.promise
+    try {
+      return await store.getters.promise
+    } catch (err) {
+      // Without this the rejected promise stays in state and is handed to every
+      // future caller, so nothing can recover without a full page reload.
+      store.commit('promise', null)
+      throw err
+    }
+  },
+
+  // Fills in geometry for the buildings whose geoJSON is not inlined in
+  // /allbuildings. Resolves rather than rejects: a missing polygon should degrade
+  // the map, not break the callers waiting on the rest of the map module.
+  async backfillGeoJSON(store) {
+    const buildingMap = store.getters.buildingMap
+    const missingIds = Array.from(buildingMap.keys()).join(',')
+    if (missingIds.length === 0) {
+      return
+    }
+    try {
+      await store.dispatch('loadGeoJSONData', missingIds)
+    } catch (err) {
+      console.error('Could not backfill building geometry from OSM:', err)
+    } finally {
+      // Cleared even on failure. Map.vue treats a non-empty buildingMap as "geometry
+      // still loading", so leaving entries behind would spin its indicator forever;
+      // better to draw the map without those few polygons.
+      buildingMap.clear()
+    }
   }
 }
 

--- a/tests/unit/store/map.module.spec.js
+++ b/tests/unit/store/map.module.spec.js
@@ -16,6 +16,34 @@ import mockAllBuildings from '../../assertedData/mock_allbuildings.json'
 // single callable that every API helper flows through.
 vi.mock('axios', () => ({ default: vi.fn() }))
 
+const emptyGeoJSON = () => JSON.stringify({ type: 'FeatureCollection', features: [] })
+
+// The map/buildings getter omits hidden buildings, so that is the count to expect.
+const visibleBuildingCount = mockAllBuildings.filter(building => !building.hidden).length
+
+// A fresh store per test — loadMap memoises into state.promise, so a shared store
+// would let one test's result leak into the next.
+const freshStore = () => createStore({ modules: { map: cloneDeep(EDMap) } })
+
+// Routes the single axios mock by URL: /allbuildings vs the Overpass interpreter
+// call that backfills geometry for buildings whose geoJSON is not inlined.
+function mockApi({ buildings, overpass }) {
+  axios.mockImplementation(url => {
+    if (String(url).includes('interpreter')) {
+      return overpass ? overpass() : Promise.resolve({ data: '<osm></osm>' })
+    }
+    return buildings ? buildings() : Promise.resolve({ data: [] })
+  })
+}
+
+// One building deliberately has no geoJSON but does have a mapId, which is what
+// pushes it into buildingMap and triggers the Overpass fetch.
+function buildingsWithOneMissingGeometry() {
+  return mockAllBuildings.map((building, index) =>
+    index === 0 ? { ...building, geoJSON: null, mapId: '92994899' } : { ...building, geoJSON: emptyGeoJSON() }
+  )
+}
+
 describe('Testing Map Module...', () => {
   // Build a fresh, isolated store from just the map module.
   const localStore = createStore({
@@ -68,5 +96,81 @@ describe('Testing Map Module...', () => {
         }
       }
     }
+  })
+})
+
+/**
+ * The buildings tab (BuildingList) and the campaign/block modules all await
+ * map/promise, but none of them render geometry — they only need building and
+ * meter-group metadata. Geometry for the handful of buildings whose geoJSON is not
+ * inlined in /allbuildings is fetched from a third-party Overpass mirror, which in
+ * practice varies from under a second to several seconds and can fail outright.
+ *
+ * Awaiting that fetch inside map/promise made every one of those consumers hostage
+ * to it: the buildings tab sat on a spinner until campus polygons arrived, and a
+ * failure left it spinning permanently.
+ */
+describe('Map module load does not block on geometry', () => {
+  it('resolves even when the Overpass geometry fetch fails', async () => {
+    const store = freshStore()
+    mockApi({
+      buildings: () => Promise.resolve({ data: buildingsWithOneMissingGeometry() }),
+      overpass: () => Promise.reject(new Error('Overpass mirror unreachable'))
+    })
+
+    // loadMap resolves to undefined, so assert on completion rather than a value.
+    let error = null
+    try {
+      await store.dispatch('map/loadMap')
+    } catch (err) {
+      error = err
+    }
+    expect(error).toBeNull()
+  })
+
+  it('exposes building metadata even when the geometry fetch fails', async () => {
+    const store = freshStore()
+    mockApi({
+      buildings: () => Promise.resolve({ data: buildingsWithOneMissingGeometry() }),
+      overpass: () => Promise.reject(new Error('Overpass mirror unreachable'))
+    })
+
+    await store.dispatch('map/loadMap')
+
+    // This is all the buildings tab needs to render.
+    expect(store.getters['map/buildings'].length).toBe(visibleBuildingCount)
+    expect(store.getters[`map/building_${mockAllBuildings[0].id}/name`]).toBe(mockAllBuildings[0].name)
+  })
+
+  it('does not block on a slow geometry fetch that never settles', async () => {
+    const store = freshStore()
+    mockApi({
+      buildings: () => Promise.resolve({ data: buildingsWithOneMissingGeometry() }),
+      // Mirrors the real hazard: axios is configured with a 72 second timeout, so a
+      // hung mirror stalls anything awaiting it for over a minute.
+      overpass: () => new Promise(() => {})
+    })
+
+    const settled = await Promise.race([
+      store.dispatch('map/loadMap').then(() => 'loaded'),
+      new Promise(resolve => setTimeout(() => resolve('still waiting'), 500))
+    ])
+
+    expect(settled).toBe('loaded')
+  })
+
+  it('clears the cached promise when the load fails so a retry can succeed', async () => {
+    const store = freshStore()
+    mockApi({ buildings: () => Promise.reject(new Error('/allbuildings unavailable')) })
+
+    await expect(store.dispatch('map/loadMap')).rejects.toThrow()
+
+    // A rejected promise left in state is returned to every future caller, so the
+    // app can never recover without a full page reload.
+    expect(store.getters['map/promise']).toBe(null)
+
+    mockApi({ buildings: () => Promise.resolve({ data: buildingsWithOneMissingGeometry() }) })
+    await store.dispatch('map/loadMap')
+    expect(store.getters['map/buildings'].length).toBe(visibleBuildingCount)
   })
 })


### PR DESCRIPTION
## Summary

- The buildings tab could sit on a spinner indefinitely, and its load time swung wildly between visits.
- It was waiting on building **geometry** — data it never renders — fetched from a third-party Overpass mirror.
- Geometry now loads in the background. The buildings tab, campaign and block modules unblock as soon as building metadata is ready.
- Also fixes a related defect where one failed load poisoned the store permanently, so nothing recovered without a full page reload.

## Root Cause

`BuildingList.mounted()` awaited `map/promise`, which is the entire map pipeline. That pipeline's last step backfills polygon geometry from a third-party Overpass mirror for the buildings whose geoJSON is not inlined in `/allbuildings`:

```js
// src/store/api.js:85
getGeoJSON: async payload =>
  callAPI(`interpreter?data=...`, null, { base: 'https://maps.mail.ru/osm/tools/overpass/api', ... })
```

The buildings tab renders names, groups and images. It needs no geometry at all — it was simply hostage to whatever else happened to live on the end of the same promise. Against production `/allbuildings`, this fires for **2 of 85 buildings** (mapIds `92994899`, `92994209`).

**Inconsistent load times.** Five identical requests to that mirror, timed:

```
0.88s   0.97s   1.28s   4.22s   6.40s
```

A 7.3× spread on an uncontrolled third-party host, sitting in the critical path of a tab that does not use the result.

**The indefinite spinner.** Two defects compounded it:

- `callAPI`'s timeout is `72000` ms (`src/store/api.js:14`), so a hung mirror stalls the tab for over a minute before it even fails.
- When it does fail, the `await` throws, so `this.loading = false` is never reached — `loading` initialises to `true` and `v-loading` never clears. And `loadMap` had no `try/catch`: it committed `mapPromise` and returned it unconditionally, so `state.promise` kept a **rejected** promise forever and handed it to every future caller. Nothing recovered short of reloading the page.

Every consumer of `map/promise` was checked — `BuildingList`, `Map.updateEnergySlopeColor`, `block.module`, `campaign.module`. **None of them uses geometry.** The only geometry consumer, `Map.vue:169`, tracks readiness through `buildingMap.size` rather than the promise, so decoupling the two is safe.

## Changes

- **`src/store/map.module.js`**: the geoJSON backfill moves into its own `backfillGeoJSON` action, dispatched **without `await`** from `loadMap`. The map picks geometry up reactively as it lands. `backfillGeoJSON` resolves rather than rejects — a missing polygon should degrade the map, not break everything waiting on the map module — and clears `buildingMap` in a `finally` even on failure, because `Map.vue:169` treats a non-empty `buildingMap` as "geometry still loading" and would otherwise spin forever. A map missing two polygons beats a permanent spinner.

- **`src/store/map.module.js`**: `loadMap` now wraps the await in `try/catch` and resets `state.promise` to `null` on failure, so a transient outage no longer permanently bricks the store.

- **`src/components/building_list/BuildingList.vue`**: `mounted()` uses `try/finally` so `loading` always clears, and dispatches `map/loadMap` instead of awaiting the `map/promise` getter directly — that getter is `null` until something else starts the load, and `await null` resolves instantly onto an empty building list.

- **`tests/unit/store/map.module.spec.js`**: four regression tests, written before the fix and confirmed failing against the old code.

## Test Plan

- [x] Tests written first and verified failing on unmodified code — 4 failed, including `expected 'still waiting' to be 'loaded'`, which reproduces the hang deterministically rather than describing it
- [x] `npm run test:unit` after the fix — **13 passed / 4 files**
- [x] `npm run format` — prettier clean, eslint no errors
- [x] `npx vite build` — succeeds
- [x] On the S3 test build, open the buildings tab on a cold load several times; it should populate as soon as `/allbuildings` returns, without waiting on `maps.mail.ru`
- [x] Confirm the map still draws every polygon, including the two backfilled ones (mapIds `92994899`, `92994209`)
- [ ] Optional, to see the old failure mode is gone: block `maps.mail.ru` in DevTools request blocking. The buildings tab should load normally; the map should draw with those two polygons missing rather than hanging

## Follow-up, not in this PR

`/buildinggeojson` (PUT) already exists so an automated job can persist geometry into the database — 83 of 85 buildings already have it inlined. Backfilling the remaining 2 would retire the runtime dependency on the Overpass mirror entirely. That is a data change rather than a code change, so it is deliberately out of scope here.
