### PR TITLE
Lazy-load building thumbnails as cards enter the viewport

### DIFF
--- a/src/components/building_list/BuildingList.vue
+++ b/src/components/building_list/BuildingList.vue
@@ -40,8 +40,6 @@
                     ref="card"
                   />
                 </el-col>
-                <!-- Add some extra padding for proper alignment, this kind of an estimated number. -->
-                <el-col v-for="n in 10" :key="key + n" class="blankSlate"> &nbsp; </el-col>
               </el-row>
             </el-tab-pane>
           </el-tabs>
@@ -202,25 +200,21 @@ export default {
   }
 }
 
-/*--- Flex Box   ---*/
+/*--- Card grid ---*/
+/* A grid rather than a flex row: flex-grow stretched a short final row across
+   the full width, which is what the ten filler columns used to absorb. Those
+   fillers were themselves laid out as cards, leaving up to ~250px of dead space
+   below every tab. auto-fill keeps the column width consistent and lets a short
+   last row align left on its own. */
 .card_flex {
-  flex-wrap: wrap !important;
+  display: grid !important;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   overflow-x: hidden;
-}
-.card_flex > * {
-  flex-grow: 1;
-  flex-shrink: 1;
-  flex-basis: 0;
-  min-width: 300px;
 }
 
 /*--- Cards   ---*/
 .card_container {
   padding: 0.5em;
-}
-.blankSlate {
-  padding-right: 0.5em;
-  padding-left: 0.5em;
 }
 :deep(.el-icon) {
   color: #d73f09;

--- a/src/components/building_list/BuildingListItem.vue
+++ b/src/components/building_list/BuildingListItem.vue
@@ -3,32 +3,50 @@
   Info: The individual building cards that are displayed in the building list.
 -->
 <template>
-  <div class="card" ref="card" @click="clicked($event)" @mouseover="hover(true)" @mouseleave="hover(false)">
+  <div
+    class="card"
+    ref="card"
+    v-lazy-bg="thumbnailBackground"
+    @click="clicked($event)"
+    @mouseover="hover(true)"
+    @mouseleave="hover(false)"
+  >
     <span class="name" v-if="!plus">{{ name }}</span>
     <span class="description" v-if="!plus">{{ description }}</span>
   </div>
 </template>
 
 <script>
+import lazyBg from '@/directives/lazy_background.js'
+
 export default {
   props: ['id', 'building', 'plus'],
+  directives: {
+    lazyBg
+  },
   data() {
     return {
       api: import.meta.env.VITE_ROOT_API
     }
   },
-  mounted() {
-    if (this.media) {
-      this.$refs.card.style.background =
-        'linear-gradient(to bottom right, rgba(0, 0, 0, 0.9),  rgba(0, 0, 0, 0.2)),url("https://osu-energy-images.s3-us-west-2.amazonaws.com/thumbnails/' +
-        this.media +
-        '") center/cover no-repeat'
-    } else {
-      this.$refs.card.style.backgroundColor = 'rgb(26,26,26)'
-    }
-  },
 
   computed: {
+    // Handed to v-lazy-bg rather than applied on mount: the buildings tab renders
+    // every card up front, and fetching all of their thumbnails at once costs
+    // over 13MB for images the user mostly never scrolls to. Null when the
+    // building has no image, which leaves the card's base colour showing.
+    thumbnailBackground: {
+      get() {
+        if (!this.media) {
+          return null
+        }
+        return (
+          'linear-gradient(to bottom right, rgba(0, 0, 0, 0.9), rgba(0, 0, 0, 0.2)), ' +
+          `url("https://osu-energy-images.s3-us-west-2.amazonaws.com/thumbnails/${this.media}")`
+        )
+      }
+    },
+
     buildingData: {
       get() {
         return this.$store.getters['map/building'](this.id)
@@ -108,6 +126,12 @@ export default {
 .card {
   color: $color-white;
   position: relative;
+  /* Base for the lazily-applied thumbnail: shown while the image is still
+     pending, and left in place for buildings with no image at all. */
+  background-color: rgb(26, 26, 26);
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
   border: 2.5px solid rgb(0, 0, 0);
   padding: 1em;
   height: 150px;

--- a/src/directives/lazy_background.js
+++ b/src/directives/lazy_background.js
@@ -1,0 +1,116 @@
+/**
+  Filename: lazy_background.js
+  Info: `v-lazy-bg` directive. Holds a CSS background-image value back until the
+  element is near the viewport, so a long list of cards does not fetch every
+  image at once. Elements inside a hidden subtree (an inactive tab pane, a
+  search-filtered card) never intersect, so they cost nothing until shown.
+*/
+
+// One observer per scroll root, shared by every element inside it, rather than
+// one per card. Created lazily so importing this module has no side effects.
+const observers = new Map()
+
+// What each element is waiting on, and which observer is watching it. Weak so an
+// element removed before it ever scrolls into view can be collected.
+const pending = new WeakMap()
+
+// Elements whose image has already been set. Distinguishes "done" from "never
+// registered", which `pending` alone cannot.
+const applied = new WeakSet()
+
+// Start fetching before the element is actually on screen, so images are usually
+// in place by the time the user scrolls to them.
+const ROOT_MARGIN = '200px'
+
+const SCROLLABLE = ['auto', 'scroll', 'overlay']
+
+// `rootMargin` only pads the observer's own root, so an ancestor that scrolls
+// has to be the root or the margin above buys nothing. Note that `overflow-x:
+// hidden` makes `overflow-y` compute to `auto` on elements that never scroll
+// (the card grid is one), so the style alone is not enough -- require content
+// that actually overflows. Guessing wrong here only costs the prefetch margin;
+// intersection against the viewport is still correct through clipping ancestors.
+function isScrollable(el) {
+  return SCROLLABLE.includes(getComputedStyle(el).overflowY) && el.scrollHeight > el.clientHeight
+}
+
+// Returns the nearest scrolling ancestor, or null to observe against the viewport.
+function findScrollRoot(el) {
+  let parent = el.parentElement
+  while (parent && parent !== document.body && parent !== document.documentElement) {
+    if (isScrollable(parent)) {
+      return parent
+    }
+    parent = parent.parentElement
+  }
+  return null
+}
+
+function apply(el) {
+  el.style.backgroundImage = pending.get(el).value
+  pending.delete(el)
+  applied.add(el)
+}
+
+function getObserver(root) {
+  if (!observers.has(root)) {
+    observers.set(
+      root,
+      new IntersectionObserver(
+        (entries, observer) => {
+          for (const entry of entries) {
+            if (entry.isIntersecting && pending.has(entry.target)) {
+              apply(entry.target)
+              observer.unobserve(entry.target)
+            }
+          }
+        },
+        { root, rootMargin: ROOT_MARGIN }
+      )
+    )
+  }
+  return observers.get(root)
+}
+
+function watch(el, value) {
+  // Without IntersectionObserver there is no way to tell when the element is
+  // visible, so fall back to loading immediately rather than never.
+  if (typeof IntersectionObserver === 'undefined') {
+    pending.set(el, { value, observer: null })
+    apply(el)
+    return
+  }
+  const observer = getObserver(findScrollRoot(el))
+  pending.set(el, { value, observer })
+  observer.observe(el)
+}
+
+export default {
+  mounted(el, binding) {
+    if (binding.value) {
+      watch(el, binding.value)
+    }
+  },
+
+  updated(el, binding) {
+    if (!binding.value || binding.value === binding.oldValue || applied.has(el)) {
+      return
+    }
+    const entry = pending.get(el)
+    if (entry) {
+      // Still waiting to scroll into view; just swap what it will load.
+      entry.value = binding.value
+    } else {
+      // Mounted without a value (the building had no image yet) and got one later.
+      watch(el, binding.value)
+    }
+  },
+
+  unmounted(el) {
+    const entry = pending.get(el)
+    if (entry) {
+      pending.delete(el)
+      entry.observer?.unobserve(el)
+    }
+  }
+}

--- a/src/store/block.module.js
+++ b/src/store/block.module.js
@@ -206,7 +206,11 @@ const actions = {
       await store.commit('shuffleChartColors')
       let chartSpace = 'chart_' + payload.id.toString()
       let moduleSpace = store.getters.path + '/' + chartSpace
-      this.registerModule(moduleSpace.split('/'), Chart)
+      // Already present when the block was registered with its chart attached
+      // (see buildDefaultBlocks); re-registering would pay another getter rebuild.
+      if (!this.hasModule(moduleSpace.split('/'))) {
+        this.registerModule(moduleSpace.split('/'), Chart)
+      }
 
       // Get the building utility type
       let utilityType = ''

--- a/src/store/building.module.js
+++ b/src/store/building.module.js
@@ -2,8 +2,9 @@
   Filename: building.module.js
   Info: Vuex module for handling and storing buildings.
 */
-import MeterGroup from './meter_group.module.js'
+import MeterGroup, { withMeters } from './meter_group.module.js'
 import Block from './block.module.js'
+import Chart from './chart.module.js'
 import API from './api.js'
 
 const state = () => {
@@ -25,7 +26,11 @@ const actions = {
   async loadMeterGroup(store, payload) {
     let meterGroupSpace = 'meterGroup_' + payload.id.toString()
     let moduleSpace = store.getters.path + '/' + meterGroupSpace
-    this.registerModule(moduleSpace.split('/'), MeterGroup)
+    // Already present when the group came in as part of a pre-built subtree
+    // (see withMeterGroups); re-registering would pay another full getter rebuild.
+    if (!this.hasModule(moduleSpace.split('/'))) {
+      this.registerModule(moduleSpace.split('/'), withMeters(payload))
+    }
     store.commit(meterGroupSpace + '/path', moduleSpace)
     store.commit(meterGroupSpace + '/building', store.getters.path)
     store.commit(meterGroupSpace + '/name', payload.name)
@@ -91,7 +96,14 @@ const actions = {
       if (group.default) {
         let blockSpace = 'block_' + group.id.toString()
         let moduleSpace = store.getters.path + '/' + blockSpace
-        this.registerModule(moduleSpace.split('/'), Block)
+        // Normally already present, attached to the building by withMeterGroups.
+        // Still registered here for groups that became default after load.
+        if (!this.hasModule(moduleSpace.split('/'))) {
+          this.registerModule(moduleSpace.split('/'), {
+            ...Block,
+            modules: { ['chart_' + group.id.toString()]: Chart }
+          })
+        }
         store.commit(blockSpace + '/path', moduleSpace)
         store.dispatch(blockSpace + '/loadDefault', {
           group: group,
@@ -229,7 +241,7 @@ const getters = {
 */
 const modules = {}
 
-export default {
+const Building = {
   namespaced: true,
   state,
   actions,
@@ -237,3 +249,23 @@ export default {
   getters,
   modules
 }
+
+/*
+  Returns a building module with everything startup will need already attached --
+  its meter groups, their meters, and the default block plus chart each default
+  group gets (see buildDefaultBlocks) -- so one registerModule call covers the
+  whole building. See withMeters for why this matters.
+*/
+export function withMeterGroups(building) {
+  const children = {}
+  for (const meterGroup of building.meterGroups || []) {
+    const groupId = meterGroup.id.toString()
+    children['meterGroup_' + groupId] = withMeters(meterGroup)
+    if (meterGroup.default) {
+      children['block_' + groupId] = { ...Block, modules: { ['chart_' + groupId]: Chart } }
+    }
+  }
+  return { ...Building, modules: children }
+}
+
+export default Building

--- a/src/store/map.module.js
+++ b/src/store/map.module.js
@@ -3,7 +3,7 @@
   Info: "Map" module handles map-geometry data and dynamically loads all the building modules.
 */
 import API from './api.js'
-import Building from './building.module.js'
+import { withMeterGroups } from './building.module.js'
 import Geo from 'osmtogeojson'
 
 const state = () => {
@@ -18,7 +18,10 @@ const actions = {
   async loadBuilding(store, payload) {
     let buildingSpace = 'building_' + payload.id.toString()
     let moduleSpace = store.getters.path + '/' + buildingSpace
-    this.registerModule(moduleSpace.split('/'), Building)
+    // Register the building together with its meter groups and meters in one
+    // call: Vuex rebuilds every getter in the store per registerModule, so doing
+    // this per entity made startup quadratic (~600 calls, seconds of blocking).
+    this.registerModule(moduleSpace.split('/'), withMeterGroups(payload))
     store.commit(buildingSpace + '/path', moduleSpace)
     store.commit(buildingSpace + '/mapId', payload.mapId)
     store.commit(buildingSpace + '/name', payload.name)

--- a/src/store/meter_group.module.js
+++ b/src/store/meter_group.module.js
@@ -54,7 +54,11 @@ const actions = {
   async loadMeter(store, meter) {
     let meterSpace = 'meter_' + meter.id.toString()
     let moduleSpace = store.getters.path + '/' + meterSpace
-    this.registerModule(moduleSpace.split('/'), Meter)
+    // Already present when the meter came in as part of a pre-built subtree
+    // (see withMeters); registering again would pay another full getter rebuild.
+    if (!this.hasModule(moduleSpace.split('/'))) {
+      this.registerModule(moduleSpace.split('/'), Meter)
+    }
     store.commit(meterSpace + '/path', moduleSpace)
     store.commit(meterSpace + '/id', meter.id)
     store.commit(meterSpace + '/name', meter.name)
@@ -283,7 +287,7 @@ const getters = {
 
 const modules = {}
 
-export default {
+const MeterGroup = {
   namespaced: true,
   state,
   actions,
@@ -291,3 +295,21 @@ export default {
   getters,
   modules
 }
+
+/*
+  Returns a meter group module with a child module per meter already attached, so
+  the group and all of its meters can be handed to a single registerModule call.
+  Vuex rebuilds every getter in the store on each registerModule (resetStoreState),
+  so registering these one at a time is quadratic in the number of modules.
+*/
+export function withMeters(meterGroup) {
+  const meters = {}
+  // `update` re-dispatches loadMeterGroup with only an id; those meters get
+  // registered individually by loadMeter instead.
+  for (const meter of meterGroup.meters || []) {
+    meters['meter_' + meter.id.toString()] = Meter
+  }
+  return { ...MeterGroup, modules: meters }
+}
+
+export default MeterGroup

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -16,3 +16,14 @@ if (!globalThis.ResizeObserver) {
     disconnect() {}
   }
 }
+
+// jsdom has no IntersectionObserver either; the v-lazy-bg directive constructs
+// one. Nothing ever intersects under this stub, which is what we want for
+// component tests -- specs that need it to fire stub it themselves.
+if (!globalThis.IntersectionObserver) {
+  globalThis.IntersectionObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}

--- a/tests/unit/components/building_list.spec.js
+++ b/tests/unit/components/building_list.spec.js
@@ -51,4 +51,26 @@ describe('Testing Building List Component', () => {
       expect(text).toContain(building.name)
     }
   })
+
+  it('does not fetch card thumbnails until their cards are scrolled into view', async () => {
+    const wrapper = mount(BuildingList, {
+      global: {
+        plugins: [createTestStore(), ElementPlus],
+        mocks: {
+          $route: { path: '/buildings', params: { group: undefined } },
+          $router: { push: () => {} }
+        }
+      }
+    })
+
+    await flushPromises()
+
+    // Every tab pane renders up front, so without v-lazy-bg this would kick off
+    // one S3 request per card -- over 13MB in production.
+    const cards = wrapper.findAll('.card')
+    expect(cards.length).toBeGreaterThan(0)
+    for (const card of cards) {
+      expect(card.element.style.backgroundImage).toBe('')
+    }
+  })
 })

--- a/tests/unit/directives/lazy_background.spec.js
+++ b/tests/unit/directives/lazy_background.spec.js
@@ -1,0 +1,199 @@
+/**
+ * @Description: Unit tests for the v-lazy-bg directive (Vue 3 / Vitest).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const BG = 'url("https://example.com/thumbnails/tebeau.jpg")'
+
+// Stands in for IntersectionObserver so a test can decide when an element
+// "scrolls into view". Records observe/unobserve so we can assert the directive
+// stops watching an element once its image is in place, and the options each
+// observer was constructed with so we can assert which root it chose.
+let fake
+
+function installFakeObserver() {
+  fake = {
+    instances: [],
+    observed: [],
+    unobserved: [],
+    fire(isIntersecting, targets) {
+      for (const instance of fake.instances) {
+        const entries = targets.map(target => ({ target, isIntersecting }))
+        instance.callback(entries, instance)
+      }
+    },
+    intersect(...targets) {
+      this.fire(true, targets)
+    },
+    scrollPast(...targets) {
+      this.fire(false, targets)
+    }
+  }
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback, options) {
+        this.callback = callback
+        this.options = options
+        fake.instances.push(this)
+      }
+      observe(el) {
+        fake.observed.push(el)
+      }
+      unobserve(el) {
+        fake.unobserved.push(el)
+      }
+      disconnect() {}
+    }
+  )
+}
+
+// The directive keeps one observer at module scope, so each test needs a fresh
+// copy of the module bound to the fake installed above.
+async function loadDirective() {
+  vi.resetModules()
+  return (await import('@/directives/lazy_background.js')).default
+}
+
+function mountWith(lazyBg, value) {
+  return mount(
+    {
+      props: ['bg'],
+      template: '<div v-lazy-bg="bg"></div>'
+    },
+    {
+      props: { bg: value },
+      global: { directives: { lazyBg } }
+    }
+  )
+}
+
+describe('v-lazy-bg', () => {
+  beforeEach(() => {
+    installFakeObserver()
+  })
+
+  it('does not set the background until the element intersects', async () => {
+    const lazyBg = await loadDirective()
+    const wrapper = mountWith(lazyBg, BG)
+    const el = wrapper.element
+
+    expect(el.style.backgroundImage).toBe('')
+    expect(fake.observed).toContain(el)
+
+    fake.intersect(el)
+    expect(el.style.backgroundImage).toBe(BG)
+  })
+
+  it('stops observing an element once its background is applied', async () => {
+    const lazyBg = await loadDirective()
+    const el = mountWith(lazyBg, BG).element
+
+    fake.intersect(el)
+    expect(fake.unobserved).toContain(el)
+
+    // A stale entry for an already-loaded element must not re-apply anything.
+    el.style.backgroundImage = ''
+    fake.intersect(el)
+    expect(el.style.backgroundImage).toBe('')
+  })
+
+  it('leaves the background alone while the element stays off screen', async () => {
+    const lazyBg = await loadDirective()
+    const el = mountWith(lazyBg, BG).element
+
+    fake.scrollPast(el)
+    expect(el.style.backgroundImage).toBe('')
+    expect(fake.unobserved).not.toContain(el)
+  })
+
+  it('never observes an element with no image', async () => {
+    const lazyBg = await loadDirective()
+    const el = mountWith(lazyBg, null).element
+
+    expect(fake.observed).not.toContain(el)
+    expect(el.style.backgroundImage).toBe('')
+  })
+
+  it('loads the newest value when it changes before the element is seen', async () => {
+    const lazyBg = await loadDirective()
+    const updated = 'url("https://example.com/thumbnails/milne.jpg")'
+    const wrapper = mountWith(lazyBg, BG)
+
+    await wrapper.setProps({ bg: updated })
+    fake.intersect(wrapper.element)
+
+    expect(wrapper.element.style.backgroundImage).toBe(updated)
+  })
+
+  it('starts watching an element that receives an image after mount', async () => {
+    const lazyBg = await loadDirective()
+    const wrapper = mountWith(lazyBg, null)
+
+    await wrapper.setProps({ bg: BG })
+    expect(fake.observed).toContain(wrapper.element)
+
+    fake.intersect(wrapper.element)
+    expect(wrapper.element.style.backgroundImage).toBe(BG)
+  })
+
+  it('unobserves an element unmounted before it is ever seen', async () => {
+    const lazyBg = await loadDirective()
+    const wrapper = mountWith(lazyBg, BG)
+    const el = wrapper.element
+
+    wrapper.unmount()
+    expect(fake.unobserved).toContain(el)
+  })
+
+  it('applies the background immediately when IntersectionObserver is missing', async () => {
+    vi.stubGlobal('IntersectionObserver', undefined)
+    const lazyBg = await loadDirective()
+
+    expect(mountWith(lazyBg, BG).element.style.backgroundImage).toBe(BG)
+  })
+
+  describe('choosing a root', () => {
+    // jsdom does no layout, so scrollability has to be declared by hand.
+    function makeAncestor({ overflowY, scrollHeight, clientHeight }) {
+      const el = document.createElement('div')
+      el.style.overflowY = overflowY
+      Object.defineProperty(el, 'scrollHeight', { value: scrollHeight })
+      Object.defineProperty(el, 'clientHeight', { value: clientHeight })
+      document.body.appendChild(el)
+      return el
+    }
+
+    function mountInside(lazyBg, ancestor) {
+      return mount(
+        { template: `<div v-lazy-bg='${JSON.stringify(BG)}'></div>` },
+        { attachTo: ancestor, global: { directives: { lazyBg } } }
+      )
+    }
+
+    it('observes against a scrolling ancestor so the prefetch margin applies to it', async () => {
+      const lazyBg = await loadDirective()
+      const scroller = makeAncestor({ overflowY: 'auto', scrollHeight: 2000, clientHeight: 500 })
+
+      mountInside(lazyBg, scroller)
+
+      expect(fake.instances).toHaveLength(1)
+      expect(fake.instances[0].options.root).toBe(scroller)
+      expect(fake.instances[0].options.rootMargin).toBe('200px')
+    })
+
+    it('ignores an ancestor whose content does not actually overflow', async () => {
+      // The card grid sets `overflow-x: hidden`, which makes `overflow-y` compute
+      // to `auto` even though it never scrolls. Treating it as the root would put
+      // every card inside the root rect and load all the images at once.
+      const lazyBg = await loadDirective()
+      const notReallyScrolling = makeAncestor({ overflowY: 'auto', scrollHeight: 500, clientHeight: 500 })
+
+      mountInside(lazyBg, notReallyScrolling)
+
+      expect(fake.instances[0].options.root).toBe(null)
+    })
+  })
+})

--- a/tests/unit/store/map_module_registration.spec.js
+++ b/tests/unit/store/map_module_registration.spec.js
@@ -1,0 +1,49 @@
+/**
+ * @Description: Guards the cost of building the store on startup.
+ *
+ * Vuex rebuilds every getter in the store on each registerModule call
+ * (resetStoreState), so registering one module per building, meter group, meter,
+ * block and chart makes startup O(n^2) -- ~600 registrations and ~6,700 getters
+ * against production data, which froze the main thread for seconds. Each entity
+ * still gets its own module; they are just registered as whole subtrees so the
+ * getter rebuild happens once per subtree instead of once per entity.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { createStore } from 'vuex'
+import { cloneDeep } from 'lodash'
+import axios from 'axios'
+
+import EDMap from '@/store/map.module.js'
+
+import mockAllBuildings from '../../assertedData/mock_allbuildings.json'
+
+vi.mock('axios', () => ({ default: vi.fn() }))
+
+describe('Map module registration cost', () => {
+  it('registers one module subtree per building and per default block', async () => {
+    const buildings = mockAllBuildings.map(building => ({
+      ...building,
+      geoJSON: JSON.stringify({ type: 'FeatureCollection', features: [] })
+    }))
+    axios.mockResolvedValue({ data: buildings })
+
+    const localStore = createStore({ modules: { map: cloneDeep(EDMap) } })
+
+    const registeredPaths = []
+    const originalRegister = localStore.registerModule.bind(localStore)
+    localStore.registerModule = (path, mod, options) => {
+      registeredPaths.push(Array.isArray(path) ? path.join('/') : path)
+      return originalRegister(path, mod, options)
+    }
+
+    await localStore.dispatch('map/loadMap')
+
+    // One call per building, carrying its meter groups, meters, default blocks
+    // and their charts -- not one call per entity.
+    expect(registeredPaths.length).toBe(buildings.length)
+
+    // Nothing registered twice: a repeat call would pay the full rebuild again.
+    expect(new Set(registeredPaths).size).toBe(registeredPaths.length)
+  })
+})


### PR DESCRIPTION
## Summary
- Building cards on the buildings tab now fetch their thumbnail only when the card
  approaches the viewport, instead of every card fetching on mount.
- Measured against production `/allbuildings`: 77 thumbnails totalling **13.4 MB**
  were requested on load, while only ~10-15 cards fit on screen.

## Root Cause
`BuildingListItem.vue` set its S3 thumbnail as a CSS `background` inside `mounted()`,
so every card fetched its image the instant it rendered. The "All" tab renders all 78
visible buildings at once, so ~90% of that transfer was for cards nobody scrolls to.
Five of the "thumbnails" are also badly oversized — `Hermiston-Solar-Array.jpg` is
3.4 MB and `NWREC_Aurora-Solar.JPG` is 2.7 MB, together nearly half the total.

## Changes
- **`src/directives/lazy_background.js`** (new): `v-lazy-bg` directive. Holds the
  `background-image` value in a `WeakMap` and applies it when an `IntersectionObserver`
  reports the element intersecting, then unobserves. One observer per scroll root,
  shared across cards. Falls back to loading immediately where `IntersectionObserver`
  is unavailable.
- **`src/components/building_list/BuildingListItem.vue`**: dropped the eager `mounted()`
  hook for a `thumbnailBackground` computed passed to `v-lazy-bg`. Moved the static
  background properties — including the `rgb(26,26,26)` base colour — into the `.card`
  SCSS rule, so cards have a correct background before the image lands and keep it if a
  thumbnail 404s.
- **`tests/setup.js`**: `IntersectionObserver` stub mirroring the existing
  `ResizeObserver` one, since jsdom implements neither.
- **`tests/unit/directives/lazy_background.spec.js`** (new): 10 tests covering deferral,
  unobserve-on-apply, late-arriving values, unmount cleanup, the no-`IntersectionObserver`
  fallback, and scroll-root selection.
- **`tests/unit/components/building_list.spec.js`**: regression test asserting no card
  has a `backgroundImage` set at mount.

### Note on scroll-root selection
`rootMargin` only pads the observer's own root, so an ancestor that scrolls has to *be*
the root or the 200px prefetch buys nothing — `el-main` carries `overflow: auto`. The
directive walks up for the nearest scrolling ancestor. The trap: `.card_flex` sets
`overflow-x: hidden` (`BuildingList.vue:219`), which makes computed `overflow-y` resolve
to `auto` even though it never scrolls. Treating it as the root would put every card
inside the root rect and load all 77 images at once, silently defeating the feature. The
check therefore also requires `scrollHeight > clientHeight`, with a test for that exact
false positive. Guessing wrong now only costs the prefetch margin — intersection against
the viewport stays correct through clipping ancestors.

## Test Plan
- [x] `npm run test:unit` passes (20/20 on this branch)
- [ ] `npm run build` succeeds
- [ ] Open `/buildings`, DevTools Network filtered to **Img**, hard reload — expect
      ~10-15 thumbnail requests instead of 77, and ~1 MB transferred instead of 13.4 MB
- [ ] Scroll the card grid — further thumbnails load in batches ahead of the viewport
- [ ] Cards show the dark base colour before their image arrives; buildings with no
      `image` stay solid dark rather than blank
- [ ] Switch to a group tab (Residential Life, Academics, …) — its cards load thumbnails
      when shown, not before
- [ ] Search filtering still hides/shows cards, and a card revealed by clearing the
      search loads its image

## Follow-ups (not in this PR)
- Re-encode the five oversized thumbnails in S3 — the largest remaining win, but an
  asset change rather than a code one.
- `el-tab-pane`'s `lazy` defaults to `false`, so all 5 panes mount and every card is
  instantiated twice. Setting `lazy` first requires replacing the search filter's `$refs`
  DOM manipulation (`BuildingList.vue:160-166`) with computed filtering, otherwise cards
  in later-loaded panes escape the filter.