### PR TITLE
Add meter class 8955 for Dixon's replacement electric meters

### DIFF
--- a/backend/dependencies/nodejs/meter_classes.js
+++ b/backend/dependencies/nodejs/meter_classes.js
@@ -87,6 +87,44 @@ export default {
     25: 'cphase_b',
     26: 'cphase_c'
   },
+  8955: {
+    // Dixon Rec Center replacement electric meters (Acquisuite 001EC60565DF).
+    //
+    // Register layout is identical to class 48 (Veris E51C2, bi-directional,
+    // full data set). Verified column-by-column against both devices' own log
+    // exports: 76 columns, every position matching class 48.
+    //
+    // Index 58 ('Reactive Power, Phase A') is deliberately left UNMAPPED. Both
+    // meters report a stuck value there (~16.9k on one, ~49k on the other)
+    // while phases B and C read single digits and index 23 agrees with
+    // B + C + a plausible A. That register is misconfigured on the device
+    // profile, so mapping it would only chart garbage. Add `58: 'reactive_a'`
+    // once the Acquisuite profile is corrected.
+    4: 'accumulated_real',
+    22: 'real_power',
+    23: 'reactive_power',
+    24: 'apparent_power',
+    55: 'real_a',
+    56: 'real_b',
+    57: 'real_c',
+    59: 'reactive_b',
+    60: 'reactive_c',
+    61: 'apparent_a',
+    62: 'apparent_b',
+    63: 'apparent_c',
+    64: 'pf_a',
+    65: 'pf_b',
+    66: 'pf_c',
+    67: 'vphase_ab',
+    68: 'vphase_bc',
+    69: 'vphase_ac',
+    70: 'vphase_an',
+    71: 'vphase_bn',
+    72: 'vphase_cn',
+    73: 'cphase_a',
+    74: 'cphase_b',
+    75: 'cphase_c'
+  },
   4444: {
     // Red Lion PAXCDC Test
     4: 'input', // Steam Flow Rate


### PR DESCRIPTION
## Summary
- Adds meter class 8955 so Dixon Rec Center's two replacement electric meters
  (217, 218) can store readings and be grouped
- Unblocks the Dixon electric cutover, which has been stalled since 2026-03-23

## Root Cause
Dixon's data acquisition server was replaced. The new electric meters register
under class 8955, which was not defined in `meter_classes.js`. Two consequences:

1. **No data stored.** `upload()` does `meterClasses[8955]` → `undefined`, then
   `Object.keys(undefined)` throws (`models/meter.js:244`). Every reading from
   these meters has been discarded since 2026-07-24.
2. **Cannot be grouped.** `calcProps()` throws at `models/meter.js:70` and the
   catch at `:85` rethrows. `Building.all()` does not catch it, so attaching
   either meter to a group would fail `/allbuildings` — which every page loads
   from, taking down the whole dashboard, not just Dixon.

The register map was recovered from the two devices' own log exports. Because
`backend/app/meter.js:186` parses uploads with a plain `entry.split(',')`, the
CSV column index *is* the register index. Both meters export 76 columns whose
positions match class 48 (Veris E51C2) exactly, so 8955 is registered as a copy
of 48.

## Changes
- **`backend/dependencies/nodejs/meter_classes.js`**: adds an 8955 entry
  mirroring class 48. Index 58 (`reactive_a`) is deliberately left unmapped —
  both meters report a stuck value there (~16.9k and ~49k) while phases B and C
  read single digits and index 23 agrees with B + C + a plausible A. The
  register is misconfigured on the Acquisuite device profile; mapping it would
  chart garbage. Reported to the metering team; add `58: 'reactive_a'` once fixed.

## Test Plan
- [ ] Merge to `master`; `API-deploy.yml` republishes `EnergyModelLayer` (prod is
      on `:93`) and updates the stack
- [ ] `GET /v2/energy/data?id=217&…&meterClass=8955` returns **200**, not the
      **502** it returns today
- [ ] `SELECT meter_id, COUNT(*) FROM data WHERE meter_id IN (217,218) GROUP BY meter_id`
      returns rows for both, growing each 15 min
- [ ] Only then run `migrations/2026-08-05-dixon-phase2-electric.sql`
- [ ] Existing meter classes unaffected — change is purely additive