### PR TITLE
Clarify chart titles for purchased vs solar electricity

### DIFF
--- a/src/store/block.module.js
+++ b/src/store/block.module.js
@@ -214,15 +214,26 @@ const actions = {
 
       // Get the building utility type
       let utilityType = ''
+      let meterClass = null
       const meters = this.getters[payload.group.path + '/meters']
       if (meters.length > 0) {
         await meters[0].promise
         utilityType = this.getters[meters[0].path + '/type']
+        meterClass = this.getters[meters[0].path + '/classInt']
       }
 
-      // This defines the "default chart" (e.g. "Total Electricity")
+      // This defines the "default chart" (e.g. "Purchased Electricity (Pacific Power)")
       // The default chart are the charts shown when user clicks on a building
-      store.commit(chartSpace + '/name', 'Total ' + utilityType)
+      //
+      // Titled by meter class rather than utility type. A Pacific Power meter and
+      // an Acquisuite meter are both type 'Electricity', but only the former is
+      // bought from the grid, and solar is measured separately at the inverter.
+
+      const classLabels = {
+        9990001: 'Solar Generation',
+        9990002: 'Purchased Electricity (Pacific Power)'
+      }
+      store.commit(chartSpace + '/name', classLabels[meterClass] || 'Total ' + utilityType)
       const pointMap = {
         Electricity: 'accumulated_real',
         Gas: 'cubic_feet',

--- a/src/store/block_modifiers/building_compare.mod.js
+++ b/src/store/block_modifiers/building_compare.mod.js
@@ -60,7 +60,7 @@ export default class CompareModifier {
   async addCharts(store, mod, ids) {
     let charts = []
     for (let i in ids) {
-      // they ignore index of 0 here due to loadDefault function in block.module.js ("Total Electricity" default block),
+      // they ignore index of 0 here due to loadDefault function in block.module.js (the default block),
       if (parseInt(i) !== 0) {
         let id = ids[i]
         let mgId = store.getters[store.getters['map/building'](id).path + '/primaryGroup']('Electricity').id


### PR DESCRIPTION
### Summary

- Default building charts were titled 'Total ' + utilityType, so every electricity meter rendered as "Total Electricity" regardless of source, and solar rendered as "Total Solar Panel"
- On buildings carrying both, "Total" implied on-site generation was included in the purchased figure when it is measured separately and sits outside it
- Titles are now keyed on meter class, so purchased grid power and on-site solar are distinguishable

### Root Cause

loadDefault derived the chart title from the meter's utility type, which is itself derived from the meter class in calcProps(). A Pacific Power meter and an Acquisuite meter both resolve to type Electricity, so the title could not distinguish "electricity bought from the grid" from "all electricity used."

That was harmless while no building had both sources. It stopped being harmless once solar was attached alongside a Pacific Power meter — three buildings now carry both: Student Experience Center (class 48 + solar), Valley Football Center (9990002 + solar), Beth Ray Center (9990002 + solar).

Reading "Total Electricity" as the whole picture understates consumption and overstates renewable share. At Valley Football Center: ~3,068 kWh/day purchased vs ~1,443 kWh/day generated — solar is 32% of true consumption, but the old labels implied 47%.

### Changes

- src/store/block.module.js: read classInt alongside type, and title the default chart from a classLabels map — 9990002 → Purchased Electricity (Pacific Power), 9990001 → Solar Generation. Falls back to the existing 'Total ' + utilityType for every other class, so gas, steam, and all Acquisuite electricity meters are unchanged. Class 48 deliberately keeps the generic title: "purchased" would be wrong for an OSU-owned building main.
- src/store/block_modifiers/building_compare.mod.js: update a comment that quoted the old "Total Electricity" string.

Deliberately not changed: the type strings in calcProps() (backend/dependencies/nodejs/models/meter.js). That looks like the tidier fix, but building_compare.mod.js:66 calls primaryGroup('Electricity') against that derived type, so renaming it there would break building-compare.

### Test Plan

- [x] Valley Football Center shows "Purchased Electricity (Pacific Power)" and "Solar Generation"
- [x] Beth Ray Center shows the same pair
- [x] SEC still shows "Total Electricity" (class 48), "Total Steam", and "Solar Generation"
- [x] A Pacific-Power-only building (e.g. Gilbert Hall) shows "Purchased Electricity (Pacific Power)"
- [x] An Acquisuite-only building (e.g. Tebeau Hall) still shows "Total Electricity"
- [x] A gas/steam building still shows "Total Natural Gas" / "Total Steam"
- [x] Building-compare still works (it resolves groups by type, untouched here)